### PR TITLE
fix: R CMD check clean + CI deploy fix

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,6 +6,8 @@
 ^default\.nix\.dup$
 ^plans$
 ^\.github$
-^vignettes/data$
+^vignettes$
+^R/dev$
 ^PLAN\.md$
+^LICENSE\.md$
 ^\.DS_Store$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,20 +3,18 @@ Title: LLM Usage Telemetry
 Version: 0.0.0.9000
 Authors@R: person("John", "Gavin", email = "john.gavin@example.com", role = c("aut", "cre"))
 Description: Telemetry, cost tracking, and automated reporting for LLM usage.
-License: MIT
+License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.3
 Imports:
-    duckdb,
+    checkmate,
+    cli,
+    DBI,
     dplyr,
-    fs,
-    ggplot2,
-    jsonlite,
-    blastula,
+    duckdb,
     here,
-    scales,
-    tibble,
-    lubridate,
+    jsonlite,
     purrr,
-    DBI
+    scales,
+    tibble

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,2 @@
+YEAR: 2026
+COPYRIGHT HOLDER: John Gavin

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,1 +1,2 @@
-exportPattern("^[^\\\\.]")
+exportPattern("^[^\\.]")
+importFrom(dplyr, desc)

--- a/R/ccusage.R
+++ b/R/ccusage.R
@@ -1,6 +1,14 @@
 # LLM Usage Tracking Functions
 # Functions for fetching, storing, and analyzing Claude Code usage data
 
+# Declare NSE variables used in dplyr pipelines
+utils::globalVariables(c(
+  "block_date", "block_hour", "block_id", "cacheCreationTokens",
+  "cacheReadTokens", "cost", "date", "fetch_timestamp", "gap_days",
+  "gap_end", "gap_start", "group", "inputTokens", "modelName",
+  "outputTokens", "timestamp", "total_cost", "total_tokens", "totalTokens"
+))
+
 #' Fetch ccusage data from command line
 #'
 #' @param type One of "daily", "weekly", "session", "blocks"

--- a/R/dev/issues/fix_9_shinylive_dashboard.R
+++ b/R/dev/issues/fix_9_shinylive_dashboard.R
@@ -1,0 +1,38 @@
+# Issue #9: Add Shinylive interactive telemetry dashboard
+# PR #10: feat/shinylive-dashboard (merged to main)
+# Follow-up: fix/dashboard-ci-and-check
+#
+# What was done:
+#   1. Created inst/scripts/export_dashboard_data.R
+#      - Flattens nested ccusage JSON to flat arrays
+#      - Exports Gemini DuckDB tables to JSON (using dbReadTable, not tbl/dbplyr)
+#      - Parses cmonitor text summary via regex
+#      - Output: 6 JSON files (~73 KB total) in vignettes/data/
+#
+#   2. Created vignettes/dashboard_shinylive.qmd
+#      - 5-tab Shinylive dashboard (Overview, Cost Trends, Tokens, Sessions, Blocks)
+#      - Uses plotly (NOT ggplot2 - avoids munsell/WebR issue)
+#      - All data loaded from JSON via relative URLs
+#      - Interactive: sliders, DT tables, plotly rangesliders, heatmaps
+#
+#   3. Created .github/workflows/deploy-dashboard.yaml
+#      - Triggers on push to main (vignettes/** or inst/extdata/**)
+#      - Installs R + Quarto + shinylive extension
+#      - Runs export script, renders dashboard, deploys to GitHub Pages
+#
+#   4. Updated inst/scripts/send_daily_email.R
+#      - Dashboard link: johngavin.github.io/llm/... -> johngavin.github.io/llmtelemetry/
+#
+#   5. Created .gitignore and .Rbuildignore
+#      - Excludes nix-shell-root, generated dashboard files, quarto cache
+#
+# CI fix (follow-up commit):
+#   - export_dashboard_data.R: replaced tbl() |> collect() with dbReadTable()
+#     to remove dbplyr dependency (not needed in CI)
+#   - .Rbuildignore: added entries for shinylive/quarto generated files
+#     to fix R CMD check warnings about 100+ byte paths
+#
+# R CMD check notes (pre-existing, not from this PR):
+#   - NSE binding warnings in R/ccusage.R (needs globalVariables())
+#   - MIT license needs + file LICENSE
+#   - NAMESPACE not managed by roxygen2

--- a/inst/scripts/export_dashboard_data.R
+++ b/inst/scripts/export_dashboard_data.R
@@ -92,12 +92,14 @@ if (file.exists(gemini_db)) {
   con <- dbConnect(duckdb(), dbdir = gemini_db, read_only = TRUE)
   on.exit(dbDisconnect(con, shutdown = TRUE), add = TRUE)
 
-  gem_daily <- tbl(con, "daily_usage") |> collect() |>
+  gem_daily <- dbReadTable(con, "daily_usage") |>
+    as_tibble() |>
     mutate(date = as.character(date), total_cost = round(total_cost, 4))
   write_json(gem_daily, file.path(out_dir, "gemini_daily.json"), auto_unbox = TRUE)
   cat(sprintf("  -> %d daily rows\n", nrow(gem_daily)))
 
-  gem_sess <- tbl(con, "sessions_summary") |> collect() |>
+  gem_sess <- dbReadTable(con, "sessions_summary") |>
+    as_tibble() |>
     mutate(
       start_time   = as.character(start_time),
       last_updated = as.character(last_updated),


### PR DESCRIPTION
## Summary

Follow-up to #10 — fixes R CMD check warnings/notes and CI deployment failure.

- Fix CI deploy: replace `tbl() |> collect()` with `dbReadTable()` to remove dbplyr dependency
- Fix DESCRIPTION: add `checkmate`/`cli` to Imports, remove unused `blastula`/`fs`/`ggplot2`/`lubridate` (script-only deps)
- Fix License: `MIT + file LICENSE`, create LICENSE file
- Fix NSE warnings: add `globalVariables()` for dplyr column names in ccusage.R
- Fix NAMESPACE: add `importFrom(dplyr, desc)`
- Fix .Rbuildignore: exclude `vignettes/` from R build (deployed via GitHub Pages only)
- Add dev log for issue #9

**R CMD check: 0 errors, 0 warnings, 0 notes**

## Test plan
- [x] `devtools::check(args = "--as-cran")` passes clean (0/0/0)
- [x] `Rscript inst/scripts/export_dashboard_data.R` works without dbplyr
- [ ] CI deploy workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)