### PR TITLE
fix: project None filter returns 0 rows; email NaN shows blank not $0

### DIFF
--- a/inst/scripts/send_daily_email.R
+++ b/inst/scripts/send_daily_email.R
@@ -348,8 +348,7 @@ if (!has_data) {
             error = function(e) NULL)
         }
         if (!is.null(model_df) && nrow(model_df) > 0) {
-          # Guard NaN and NA in cost_per_mtok (is.na catches both NA and NaN)
-          model_df$cost_per_mtok[is.na(model_df$cost_per_mtok)] <- 0
+          model_df$cost_per_mtok[is.nan(model_df$cost_per_mtok)] <- 0
 
           daily_model_html <- sprintf('\n<h3 style="color: %s; margin-top: 20px;">Daily Cost by Model (Last 5 Days)</h3>
 <table style="border-collapse: collapse; width: 100%%;">

--- a/vignettes/dashboard_shinylive.qmd
+++ b/vignettes/dashboard_shinylive.qmd
@@ -798,7 +798,7 @@ server <- function(input, output, session) {
   cc_d_proj <- reactive({
     d <- cc_d()
     if (nrow(d) == 0) return(d)
-    if (length(input$projects) > 0) d <- d[d$project %in% input$projects, ]
+    d <- d[d$project %in% input$projects, ]
     d
   })
 
@@ -956,9 +956,7 @@ server <- function(input, output, session) {
     if (!is.null(input$date_range) && length(input$date_range) == 2) {
       d <- d[d$date >= input$date_range[1] & d$date <= input$date_range[2], ]
     }
-    if (length(input$projects) > 0) {
-      d <- d[d$project %in% input$projects, ]
-    }
+    d <- d[d$project %in% input$projects, ]
     if (nrow(d) == 0) return(ec_empty("No data for selected filters"))
 
     all_d <- sort(unique(d$date))
@@ -1179,7 +1177,7 @@ server <- function(input, output, session) {
   output$vb_sess_count <- renderText({
     if (!has_rows(u_sessions)) return("0")
     d <- u_sessions[u_sessions$date >= cutoff(), ]
-    if (length(input$projects) > 0 && !all(all_projects %in% input$projects)) {
+    if (!all(all_projects %in% input$projects)) {
       d <- d[d$project_short %in% input$projects, ]
     }
     as.character(nrow(d))
@@ -1187,7 +1185,7 @@ server <- function(input, output, session) {
   output$vb_sess_duration <- renderText({
     if (!has_rows(u_sessions)) return("0 min")
     d <- u_sessions[u_sessions$date >= cutoff(), ]
-    if (length(input$projects) > 0 && !all(all_projects %in% input$projects)) {
+    if (!all(all_projects %in% input$projects)) {
       d <- d[d$project_short %in% input$projects, ]
     }
     total <- sum(d$duration_min, na.rm = TRUE)
@@ -1196,7 +1194,7 @@ server <- function(input, output, session) {
   output$vb_sess_avg <- renderText({
     if (!has_rows(u_sessions)) return("0 min")
     d <- u_sessions[u_sessions$date >= cutoff(), ]
-    if (length(input$projects) > 0 && !all(all_projects %in% input$projects)) {
+    if (!all(all_projects %in% input$projects)) {
       d <- d[d$project_short %in% input$projects, ]
     }
     if (nrow(d) == 0) return("0 min")
@@ -1208,7 +1206,7 @@ server <- function(input, output, session) {
     if (!has_rows(u_sessions)) return(datatable(data.frame()))
     d <- u_sessions[u_sessions$date >= cutoff(), ]
     # Filter by selected projects
-    if (length(input$projects) > 0 && "project_short" %in% names(d)) {
+    if ("project_short" %in% names(d)) {
       d <- d[d$project_short %in% input$projects, ]
     }
     if (nrow(d) == 0) return(datatable(data.frame(Message = "No sessions for selected projects")))
@@ -1243,7 +1241,7 @@ server <- function(input, output, session) {
     if (!has_rows(u_sessions)) return(ec_empty())
     d <- u_sessions[u_sessions$date >= cutoff() & u_sessions$duration_min > 0, ]
     # Filter by selected projects
-    if (length(input$projects) > 0 && "project_short" %in% names(d)) {
+    if ("project_short" %in% names(d)) {
       d <- d[d$project_short %in% input$projects, ]
     }
     if (nrow(d) == 0) return(ec_empty("No sessions for selected projects"))
@@ -1257,7 +1255,7 @@ server <- function(input, output, session) {
     if (!has_rows(u_sessions)) return(ec_empty())
     d <- u_sessions[u_sessions$date >= cutoff() & u_sessions$duration_min > 0, ]
     # Filter by selected projects
-    if (length(input$projects) > 0 && "project_short" %in% names(d)) {
+    if ("project_short" %in% names(d)) {
       d <- d[d$project_short %in% input$projects, ]
     }
     if (nrow(d) == 0) return(ec_empty("No sessions for selected projects"))
@@ -1292,7 +1290,7 @@ server <- function(input, output, session) {
     # Shorten project names for display
     d$project_short <- shorten_proj(d$project)
     # Filter by selected projects
-    if (length(input$projects) > 0 && !all(all_projects %in% input$projects)) {
+    if (!all(all_projects %in% input$projects)) {
       d <- d[d$project_short %in% input$projects, ]
     }
     d
@@ -1323,7 +1321,7 @@ server <- function(input, output, session) {
     if (!has_rows(u_sessions)) return(ec_empty())
     d <- u_sessions[u_sessions$date >= cutoff(), ]
     # Filter by selected projects
-    if (length(input$projects) > 0 && !all(all_projects %in% input$projects)) {
+    if (!all(all_projects %in% input$projects)) {
       d <- d[d$project_short %in% input$projects, ]
     }
     if (nrow(d) == 0) return(ec_empty())
@@ -1372,7 +1370,7 @@ server <- function(input, output, session) {
   output$proj_duration <- renderUI({
     if (!has_rows(u_sessions)) return(ec_empty())
     d <- u_sessions[u_sessions$date >= cutoff(), ]
-    if (length(input$projects) > 0 && !all(all_projects %in% input$projects)) {
+    if (!all(all_projects %in% input$projects)) {
       d <- d[d$project_short %in% input$projects, ]
     }
     if (nrow(d) == 0 || !"duration_min" %in% names(d)) return(ec_empty())


### PR DESCRIPTION
## Summary

### Project filter — None button now works (roborev jobs #982, #989)
The **None** button set `input$projects` to `character(0)`, but every filter site guarded with `length(input$projects) > 0`, treating empty selection as \"no filter\" and showing all projects instead of none.

9 sites fixed across three patterns:
| Pattern | Locations | Fix |
|---------|-----------|-----|
| `if (length > 0) d <- d[%in%]` | `cc_d_proj`, cost chart (2×) | Remove guard; `%in% character(0)` returns all FALSE → 0 rows |
| `if (length > 0 && !all(all_projects %in% x))` | 5× value boxes + By-Project charts | Drop `length > 0 &&`; condition is already TRUE for empty selection |
| `if (length > 0 && "project_short" %in% names(d))` | session table, hist, scatter (3×) | Drop `length > 0 &&`; column guard preserved |

### Email NaN (roborev job #897)
`is.na(cost_per_mtok) <- 0` coerced genuine missing rows to `$0.00`. Changed to `is.nan()` so only true 0/0 arithmetic is zeroed; genuine NAs reach `fmt_usd()` which returns `"-"`.

## Test plan
- [ ] Click **None** in project filter — all charts/tables show empty state, not all data
- [ ] Click **All** — full data restored
- [ ] Click **Invert** from partial selection — correct complement shown
- [ ] Run daily email against model_daily.json with a row where cost/tokens are NA — column shows `-` not `$0.00`

🤖 Generated with [Claude Code](https://claude.com/claude-code)