### PR TITLE
fix: ARIA + fullscreen sweep — role=button, keyboard handler, ec_scatter parity

### DIFF
--- a/vignettes/dashboard_shinylive.qmd
+++ b/vignettes/dashboard_shinylive.qmd
@@ -55,18 +55,20 @@ ec <- function(option, h = "300px", aria_label = "Interactive chart") {
   id <- paste0("ec", sample.int(1e7, 1))
   j <- toJSON(option, auto_unbox = TRUE, null = "null")
   tagList(
-    tags$div(id = id, class = "echart-div", role = "img", `aria-label` = aria_label,
+    tags$div(id = id, class = "echart-div", role = "button", `aria-label` = aria_label,
+             tabindex = "0",
              style = paste0("width:100%;height:", h, ";cursor:zoom-in")),
     tags$script(HTML(paste0(
       "(function(){var c=echarts.init(document.getElementById('", id,
       "'),'dark');c.setOption(", j, ");new ResizeObserver(function(){c.resize()})",
       ".observe(document.getElementById('", id, "'));",
-      # Click-to-fullscreen: export chart as image and show in overlay
-      "document.getElementById('", id, "').addEventListener('click',function(){",
-      "var url=c.getDataURL({type:'png',pixelRatio:2,backgroundColor:'#000'});",
+      "function fs(){var url=c.getDataURL({type:'png',pixelRatio:2,backgroundColor:'#000'});",
       "var ov=document.createElement('div');ov.className='fullscreen-overlay';",
       "var img=document.createElement('img');img.src=url;ov.appendChild(img);",
-      "ov.onclick=function(){ov.remove()};document.body.appendChild(ov)})})();"
+      "ov.onclick=function(){ov.remove()};document.body.appendChild(ov)}",
+      "document.getElementById('", id, "').addEventListener('click',fs);",
+      "document.getElementById('", id, "').addEventListener('keydown',function(e){",
+      "if(e.key==='Enter'||e.key===' '){e.preventDefault();fs()}})})();"
     )))
   )
 }
@@ -122,7 +124,8 @@ ec_bar <- function(cats, series, h = "300px", y_name = NULL, aria_label = "Bar c
 }
 
 ec_scatter <- function(data_pts, color = "#377eb8", h = "300px",
-                       x_type = "value", size_col = 3, scale = 3) {
+                       x_type = "value", size_col = 3, scale = 3,
+                       aria_label = "Scatter chart") {
   id <- paste0("ec", sample.int(1e7, 1))
   opt <- list(
     tooltip = list(trigger = "item"),
@@ -134,14 +137,22 @@ ec_scatter <- function(data_pts, color = "#377eb8", h = "300px",
   )
   j <- toJSON(opt, auto_unbox = TRUE, null = "null")
   tagList(
-    tags$div(id = id, class = "echart-div", style = paste0("width:100%;height:", h)),
+    tags$div(id = id, class = "echart-div", role = "button", `aria-label` = aria_label,
+             tabindex = "0", style = paste0("width:100%;height:", h, ";cursor:zoom-in")),
     tags$script(HTML(paste0(
       "(function(){var c=echarts.init(document.getElementById('", id, "'),'dark');",
       "var o=", j, ";",
       "o.series[0].symbolSize=function(d){return Math.max(5,Math.sqrt(Math.abs(d[",
       size_col - 1, "]))*", scale, ")};",
       "c.setOption(o);new ResizeObserver(function(){c.resize()})",
-      ".observe(document.getElementById('", id, "'))})();"
+      ".observe(document.getElementById('", id, "'));",
+      "function fs(){var url=c.getDataURL({type:'png',pixelRatio:2,backgroundColor:'#000'});",
+      "var ov=document.createElement('div');ov.className='fullscreen-overlay';",
+      "var img=document.createElement('img');img.src=url;ov.appendChild(img);",
+      "ov.onclick=function(){ov.remove()};document.body.appendChild(ov)}",
+      "document.getElementById('", id, "').addEventListener('click',fs);",
+      "document.getElementById('", id, "').addEventListener('keydown',function(e){",
+      "if(e.key==='Enter'||e.key===' '){e.preventDefault();fs()}})})();"
     )))
   )
 }
@@ -1502,14 +1513,23 @@ server <- function(input, output, session) {
     )
     j <- toJSON(opt, auto_unbox = TRUE, null = "null")
     tagList(
-      tags$div(id = id, class = "echart-div", style = "width:100%;height:300px"),
+      tags$div(id = id, class = "echart-div", role = "button",
+               `aria-label` = "Cost vs duration scatter chart — click to enlarge",
+               tabindex = "0", style = "width:100%;height:300px;cursor:zoom-in"),
       tags$script(HTML(paste0(
         "(function(){var c=echarts.init(document.getElementById('", id, "'),'dark');",
         "var o=", j, ";",
         "o.series[0].symbolSize=function(d){return Math.max(6,Math.sqrt(d[2])*8)};",
         "o.tooltip.formatter=function(p){return '$'+p.value[0].toFixed(2)+' | '+p.value[1].toFixed(1)+'h'};",
         "c.setOption(o);new ResizeObserver(function(){c.resize()})",
-        ".observe(document.getElementById('", id, "'))})();"
+        ".observe(document.getElementById('", id, "'));",
+        "function fs(){var url=c.getDataURL({type:'png',pixelRatio:2,backgroundColor:'#000'});",
+        "var ov=document.createElement('div');ov.className='fullscreen-overlay';",
+        "var img=document.createElement('img');img.src=url;ov.appendChild(img);",
+        "ov.onclick=function(){ov.remove()};document.body.appendChild(ov)}",
+        "document.getElementById('", id, "').addEventListener('click',fs);",
+        "document.getElementById('", id, "').addEventListener('keydown',function(e){",
+        "if(e.key==='Enter'||e.key===' '){e.preventDefault();fs()}})})();"
       )))
     )
   })


### PR DESCRIPTION
## Summary

Closes roborev jobs **#946** and **#940** in a single pass.

### `ec()` — all 30+ charts routed through this function
- `role="img"` → `role="button"`: the element has a click handler; `img` gives AT a non-interactive semantic
- Added `tabindex="0"`: keyboard users can now focus the chart
- Refactored fullscreen into named `fs()` function shared by `click` and `keydown` handlers
- **Enter** or **Space** now triggers fullscreen (keyboard parity with mouse click)

### `ec_scatter()` — was entirely missing ARIA and fullscreen
- Added `role="button"`, `aria-label`, `tabindex="0"`, `cursor:zoom-in`
- Same `fs()` + click + keydown pattern
- New `aria_label` parameter (default `"Scatter chart"`)

### `output$block_timeline` bespoke chart — raw `echarts.init`, no ARIA
- Added `role="button"`, descriptive `aria-label`, `tabindex="0"`, `cursor:zoom-in`
- Same fullscreen pattern

## Test plan
- [ ] Tab to a chart in the dashboard — focus ring appears
- [ ] Press Enter on focused chart — fullscreen overlay opens
- [ ] Press Space on focused chart — same
- [ ] Click still works (regression check)
- [ ] Screen reader announces chart label (e.g. "Daily cost line chart, button")

🤖 Generated with [Claude Code](https://claude.com/claude-code)