### PR TITLE
fix: normalize ended_at >= started_at before JSON export

### DIFF
--- a/inst/scripts/export_dashboard_data.R
+++ b/inst/scripts/export_dashboard_data.R
@@ -518,9 +518,11 @@ if (file.exists(unified_db)) {
   u_sess <- dbReadTable(ucon, "sessions") |>
     as_tibble() |>
     mutate(
+      # Normalize ended_at: ccusage occasionally exports ended_at < started_at
+      # (UTC vs local timezone mismatch). Clamp to started_at before converting
+      # to character so both fields stay monotonic.
+      ended_at = as.character(pmax(ended_at, started_at)),
       started_at = as.character(started_at),
-      ended_at = as.character(ended_at),
-      # Guard against negative durations (timezone issues)
       duration_min = pmax(0, round(duration_min, 1), na.rm = TRUE)
     ) |>
     select(session_id, project, started_at, ended_at, duration_min) |>


### PR DESCRIPTION
## Summary

Closes roborev job **#1055**.

`ccusage` occasionally exports sessions where `ended_at` predates `started_at` by ~1 hour (UTC vs local timezone mismatch in the ccusage CLI). `duration_min` was already clamped to `0` via `pmax`, but the raw timestamp fields remained contradictory in the exported JSON.

**Fix:** `pmax(ended_at, started_at)` while both columns are still `POSIXct` (before `as.character()` conversion). When `ended_at < started_at`, the exported value becomes `started_at`, consistent with the zero-clamped `duration_min`.

```r
# Before
started_at = as.character(started_at),
ended_at   = as.character(ended_at),          # could be < started_at

# After  
ended_at   = as.character(pmax(ended_at, started_at)),  # normalise first
started_at = as.character(started_at),
```

## Test plan
- [ ] Run `export_dashboard_data.R` and check `unified_sessions.json` — no rows where `ended_at < started_at`
- [ ] Sessions with previously-negative durations should show `duration_min = 0` and `ended_at == started_at`

🤖 Generated with [Claude Code](https://claude.com/claude-code)