### PR TITLE
feat(#27): Phase 3 — UI refresh (3-mo default, granularity, value_box drop, 4 new charts)

### DIFF
--- a/vignettes/dashboard_shinylive.qmd
+++ b/vignettes/dashboard_shinylive.qmd
@@ -670,23 +670,30 @@ ui <- page_navbar(
   ),
 
   nav_panel("Overview", value = "Overview",
-    layout_columns(
-      fill = FALSE, col_widths = c(3, 3, 3, 3),
-      tooltip(
-        value_box("Total Cost", textOutput("vb_cost"), theme = "primary"),
-        "Sum of API charges for input, output, and cache tokens (Claude + Gemini)"
-      ),
-      tooltip(
-        value_box("Total Tokens", textOutput("vb_tokens"), theme = "info"),
-        "Sum of input + output + cache tokens across all providers"
-      ),
-      tooltip(
-        value_box("Active Days", textOutput("vb_days"), theme = "success"),
-        "Days with at least one API call in the selected time horizon"
-      ),
-      tooltip(
-        value_box("Sessions", textOutput("vb_sessions"), theme = "warning"),
-        "Claude Code sessions from unified.duckdb telemetry"
+    layout_columns(col_widths = c(4),
+      card(
+        card_header("Overview Summary"),
+        tags$table(class = "table table-sm table-dark mb-0",
+          tags$thead(tags$tr(tags$th("Metric"), tags$th("Value"))),
+          tags$tbody(
+            tooltip(
+              tags$tr(tags$td("Total Cost"), tags$td(textOutput("vb_cost", inline = TRUE))),
+              "Sum of API charges for input, output, and cache tokens (Claude + Gemini)"
+            ),
+            tooltip(
+              tags$tr(tags$td("Total Tokens"), tags$td(textOutput("vb_tokens", inline = TRUE))),
+              "Sum of input + output + cache tokens across all providers"
+            ),
+            tooltip(
+              tags$tr(tags$td("Active Days"), tags$td(textOutput("vb_days", inline = TRUE))),
+              "Days with at least one API call in the selected time horizon"
+            ),
+            tooltip(
+              tags$tr(tags$td("Sessions"), tags$td(textOutput("vb_sessions", inline = TRUE))),
+              "Claude Code sessions from unified.duckdb telemetry"
+            )
+          )
+        )
       )
     ),
     layout_columns(col_widths = c(12),
@@ -728,19 +735,26 @@ ui <- page_navbar(
   ),
 
   nav_panel("Sessions", value = "Sessions",
-    layout_columns(
-      fill = FALSE, col_widths = c(4, 4, 4),
-      tooltip(
-        value_box("API Conversations", textOutput("vb_sess_count"), theme = "primary"),
-        "Count of Claude Code conversations (each restart = new session)"
-      ),
-      tooltip(
-        value_box("Total Duration", textOutput("vb_sess_duration"), theme = "info"),
-        "Sum of all conversation durations (minutes)"
-      ),
-      tooltip(
-        value_box("Avg Duration", textOutput("vb_sess_avg"), theme = "success"),
-        "Average conversation length (minutes)"
+    layout_columns(col_widths = c(4),
+      card(
+        card_header("Sessions Summary"),
+        tags$table(class = "table table-sm table-dark mb-0",
+          tags$thead(tags$tr(tags$th("Metric"), tags$th("Value"))),
+          tags$tbody(
+            tooltip(
+              tags$tr(tags$td("API Conversations"), tags$td(textOutput("vb_sess_count", inline = TRUE))),
+              "Count of Claude Code conversations (each restart = new session)"
+            ),
+            tooltip(
+              tags$tr(tags$td("Total Duration"), tags$td(textOutput("vb_sess_duration", inline = TRUE))),
+              "Sum of all conversation durations (minutes)"
+            ),
+            tooltip(
+              tags$tr(tags$td("Avg Duration"), tags$td(textOutput("vb_sess_avg", inline = TRUE))),
+              "Average conversation length (minutes)"
+            )
+          )
+        )
       )
     ),
     layout_columns(col_widths = c(6, 6),
@@ -790,19 +804,26 @@ ui <- page_navbar(
   ),
 
   nav_panel("Git", value = "Git",
-    layout_columns(
-      fill = FALSE, col_widths = c(4, 4, 4),
-      tooltip(
-        value_box("Total Commits", textOutput("vb_commits"), theme = "primary"),
-        "Git commits for selected repo (or all tracked repos)"
-      ),
-      tooltip(
-        value_box("Median Lines", textOutput("vb_median_lines"), theme = "info"),
-        "Median lines changed per commit (additions + deletions)"
-      ),
-      tooltip(
-        value_box("Mean Lines", textOutput("vb_mean_lines"), theme = "success"),
-        "Mean lines changed per commit (additions + deletions)"
+    layout_columns(col_widths = c(4),
+      card(
+        card_header("Git Summary"),
+        tags$table(class = "table table-sm table-dark mb-0",
+          tags$thead(tags$tr(tags$th("Metric"), tags$th("Value"))),
+          tags$tbody(
+            tooltip(
+              tags$tr(tags$td("Total Commits"), tags$td(textOutput("vb_commits", inline = TRUE))),
+              "Git commits for selected repo (or all tracked repos)"
+            ),
+            tooltip(
+              tags$tr(tags$td("Median Lines"), tags$td(textOutput("vb_median_lines", inline = TRUE))),
+              "Median lines changed per commit (additions + deletions)"
+            ),
+            tooltip(
+              tags$tr(tags$td("Mean Lines"), tags$td(textOutput("vb_mean_lines", inline = TRUE))),
+              "Mean lines changed per commit (additions + deletions)"
+            )
+          )
+        )
       )
     ),
     layout_columns(col_widths = c(12),

--- a/vignettes/dashboard_shinylive.qmd
+++ b/vignettes/dashboard_shinylive.qmd
@@ -84,7 +84,7 @@ ec_empty <- function(msg = "No data available", h = "300px") {
 
 ec_line <- function(dates, series, h = "300px", y_name = NULL, aria_label = "Line chart",
                     default_window_days = 90) {
-  y_axis <- list(type = "value")
+  y_axis <- list(type = "value", scale = TRUE)
   if (!is.null(y_name)) y_axis$name <- y_name
   # Compute dynamic dataZoom start to default to last ~3 months
   dz_start <- 0
@@ -106,8 +106,8 @@ ec_line <- function(dates, series, h = "300px", y_name = NULL, aria_label = "Lin
       saveAsImage = list()
     )),
     dataZoom = list(
-      list(type = "inside", start = dz_start, end = 100),
-      list(type = "slider", start = dz_start, end = 100, bottom = 5)
+      list(type = "inside", start = dz_start, end = 100, filterMode = "filter"),
+      list(type = "slider", start = dz_start, end = 100, bottom = 5, filterMode = "filter")
     ),
     grid = list(containLabel = TRUE, bottom = 80),
     xAxis = list(type = "category", data = I(as.character(dates))),
@@ -816,7 +816,7 @@ ui <- page_navbar(
 
   nav_panel("Git", value = "Git",
     layout_columns(col_widths = c(4),
-      card(
+      card(min_height = "400px",
         card_header("Git Summary"),
         tags$table(class = "table table-sm table-dark mb-0",
           tags$thead(tags$tr(tags$th("Metric"), tags$th("Value"))),
@@ -838,58 +838,58 @@ ui <- page_navbar(
       )
     ),
     layout_columns(col_widths = c(12),
-      card(card_header("Commits by Repo"), DTOutput("commits_by_proj"),
+      card(min_height = "400px", card_header("Commits by Repo"), DTOutput("commits_by_proj"),
         card_footer(class = "text-muted small",
           "All tracked repos — commits, lines added/deleted. Use Repo filter in sidebar to drill down."))
     ),
     layout_columns(col_widths = c(12),
-      card(card_header("Lines Changed per Commit"), uiOutput("commit_hist"),
+      card(min_height = "400px", card_header("Lines Changed per Commit"), uiOutput("commit_hist"),
         card_footer(class = "text-muted small", "Distribution of total lines changed per commit (selected repo)"))
     ),
     layout_columns(col_widths = c(6, 6),
-      card(card_header("Lines Changed Over Time"), uiOutput("commit_scatter_time"),
+      card(min_height = "400px", card_header("Lines Changed Over Time"), uiOutput("commit_scatter_time"),
         card_footer(class = "text-muted small", "Lines changed per commit over time, sized by files changed")),
-      card(card_header("Additions vs Deletions"), uiOutput("commit_scatter_add_del"),
+      card(min_height = "400px", card_header("Additions vs Deletions"), uiOutput("commit_scatter_add_del"),
         card_footer(class = "text-muted small", "Lines added vs deleted per commit"))
     ),
     layout_columns(col_widths = c(6, 6),
-      card(card_header("Bus Factor (All Time)"), uiOutput("rh_bus_all"),
+      card(min_height = "400px", card_header("Bus Factor (All Time)"), uiOutput("rh_bus_all"),
         card_footer(class = "text-muted small", "Contributor commit share — 1 person at 60%+ = risk")),
-      card(card_header("Bus Factor (6 Months)"), uiOutput("rh_bus_6mo"),
+      card(min_height = "400px", card_header("Bus Factor (6 Months)"), uiOutput("rh_bus_6mo"),
         card_footer(class = "text-muted small", "Recent contributor concentration"))
     ),
     layout_columns(col_widths = c(6, 6),
-      card(card_header("Velocity Trend"), uiOutput("rh_velocity"),
+      card(min_height = "400px", card_header("Velocity Trend"), uiOutput("rh_velocity"),
         card_footer(class = "text-muted small", "Commits per month")),
-      card(card_header("Commit Timing Heatmap"), uiOutput("rh_timing"),
+      card(min_height = "400px", card_header("Commit Timing Heatmap"), uiOutput("rh_timing"),
         card_footer(class = "text-muted small", "When commits happen — hour vs day of week"))
     ),
     layout_columns(col_widths = c(12),
-      card(card_header("File Growth (6-Month Rolling)"), uiOutput("rh_file_growth"),
+      card(min_height = "400px", card_header("File Growth (6-Month Rolling)"), uiOutput("rh_file_growth"),
         card_footer(class = "text-muted small", "6-month rolling aggregate of files added vs deleted — green = additions, red = deletions"))
     ),
     layout_columns(col_widths = c(6, 6),
-      card(card_header("Churn Hotspots"), uiOutput("rh_churn"),
+      card(min_height = "400px", card_header("Churn Hotspots"), uiOutput("rh_churn"),
         card_footer(class = "text-muted small", "Most-modified files in last 6 months")),
-      card(card_header("Bug Hotspots"), uiOutput("rh_bugs"),
+      card(min_height = "400px", card_header("Bug Hotspots"), uiOutput("rh_bugs"),
         card_footer(class = "text-muted small", "Files most often touched by fix/bug commits"))
     ),
     layout_columns(col_widths = c(6, 6),
-      card(card_header("TODO/FIXME Debt"), DTOutput("rh_todo"),
+      card(min_height = "400px", card_header("TODO/FIXME Debt"), DTOutput("rh_todo"),
         card_footer(class = "text-muted small", "Technical debt markers by file")),
-      card(card_header("Crisis Commits"), DTOutput("rh_crisis"),
+      card(min_height = "400px", card_header("Crisis Commits"), DTOutput("rh_crisis"),
         card_footer(class = "text-muted small", "Reverts, hotfixes, and emergency commits (last year)"))
     ),
     layout_columns(col_widths = c(12),
-      card(card_header("GitHub Issue Activity (Last 30 Days)"), uiOutput("gh_events_chart"),
+      card(min_height = "400px", card_header("GitHub Issue Activity (Last 30 Days)"), uiOutput("gh_events_chart"),
         card_footer(class = "text-muted small", "Issue open/close/label events across tracked repos"))
     ),
     layout_columns(col_widths = c(12),
-      card(card_header("File Churn Hotspots (Phase 2)"), DTOutput("file_churn_table"),
+      card(min_height = "400px", card_header("File Churn Hotspots (Phase 2)"), DTOutput("file_churn_table"),
         card_footer(class = "text-muted small", "Top files by lines changed over the last year, by project. Hotspots = high-risk surface area."))
     ),
     layout_columns(col_widths = c(12),
-      card(card_header("Change Coupling Graph (Phase 2)"), uiOutput("change_coupling_graph"),
+      card(min_height = "400px", card_header("Change Coupling Graph (Phase 2)"), uiOutput("change_coupling_graph"),
         card_footer(class = "text-muted small", "Files that frequently change together. Hover an edge to see co-change count. Highly-coupled clusters suggest hidden module boundaries. Filter by Repo in sidebar."))
     )
   ),
@@ -1694,7 +1694,7 @@ server <- function(input, output, session) {
     datatable(out,
       caption = "File churn by lines changed (top files per project)",
       options = list(
-        pageLength = 15, dom = "ftip", scrollX = TRUE,
+        pageLength = 15, dom = "ftip", scrollX = TRUE, scrollY = "350px",
         order = list(list(which(cols == "total_lines_changed") - 1L, "desc"))
       ),
       rownames = FALSE
@@ -1757,6 +1757,8 @@ server <- function(input, output, session) {
   output$block_table <- renderDT({
     d <- blk()
     if (nrow(d) == 0) return(datatable(data.frame()))
+    # Sort most-recent-first so display order is newest at top
+    d <- d[order(d$startTime, decreasing = TRUE), ]
     n <- nrow(d)
     eff_end <- coalesce2(d$actualEndTime, d$endTime)
     out <- data.frame(

--- a/vignettes/dashboard_shinylive.qmd
+++ b/vignettes/dashboard_shinylive.qmd
@@ -640,6 +640,9 @@ ui <- page_navbar(
   ),
   sidebar = sidebar(
     width = 220,
+    selectInput("granularity", "Time granularity:",
+      choices = c("Daily" = "daily", "Weekly" = "weekly", "Monthly" = "monthly"),
+      selected = "weekly"),
     sliderInput("horizon", "Time Horizon (days)",
       min = 1, max = 30, value = 30, step = 1),
     conditionalPanel(
@@ -718,6 +721,10 @@ ui <- page_navbar(
         card_footer(class = "text-muted small", "Weekly cost grouped by Claude vs Gemini")),
       card(card_header("Weekly Cost by Model"), uiOutput("cost_by_model"),
         card_footer(class = "text-muted small", "Weekly cost by Claude model variant"))
+    ),
+    layout_columns(col_widths = c(12),
+      card(card_header("Cost per Commit Trend"), uiOutput("cost_per_commit_chart"),
+        card_footer(class = "text-muted small", "Estimated cost per commit (USD) over time by project. Lower = more efficient sessions per code change. Granularity toggle applies."))
     )
   ),
 
@@ -787,6 +794,10 @@ ui <- page_navbar(
         card_footer(class = "text-muted small", "Total session minutes per project")),
       card(card_header("Cost Share by Date"), uiOutput("proj_share_heatmap"),
         card_footer(class = "text-muted small", "Heatmap: project cost share by date"))
+    ),
+    layout_columns(col_widths = c(12),
+      card(card_header("Weekly Commit Heatmap"), uiOutput("proj_weekly_heatmap"),
+        card_footer(class = "text-muted small", "Weekly commit counts across tracked repos. X = ISO week, Y = project, colour = commit count. Default view: last 13 weeks."))
     )
   ),
 
@@ -872,6 +883,14 @@ ui <- page_navbar(
     layout_columns(col_widths = c(12),
       card(card_header("GitHub Issue Activity (Last 30 Days)"), uiOutput("gh_events_chart"),
         card_footer(class = "text-muted small", "Issue open/close/label events across tracked repos"))
+    ),
+    layout_columns(col_widths = c(12),
+      card(card_header("File Churn Hotspots (Phase 2)"), DTOutput("file_churn_table"),
+        card_footer(class = "text-muted small", "Top files by lines changed over the last year, by project. Hotspots = high-risk surface area."))
+    ),
+    layout_columns(col_widths = c(12),
+      card(card_header("Change Coupling Graph (Phase 2)"), uiOutput("change_coupling_graph"),
+        card_footer(class = "text-muted small", "Files that frequently change together. Hover an edge to see co-change count. Highly-coupled clusters suggest hidden module boundaries. Filter by Repo in sidebar."))
     )
   ),
 
@@ -1590,6 +1609,143 @@ server <- function(input, output, session) {
         emphasis = list(itemStyle = list(shadowBlur = 10, shadowColor = "rgba(0,0,0,0.5)"))
       ))
     ), h = "300px", aria_label = "Heatmap: project cost share percentage by date")
+  })
+
+  # --- Phase 2: Weekly Commit Heatmap (By Project tab) -----------------------
+  output$proj_weekly_heatmap <- renderUI({
+    if (!has_rows(weekly_commits)) return(ec_empty("No weekly commit data available"))
+    d <- weekly_commits
+    # Filter to selected repos if sidebar has a selection
+    if (!is.null(input$commit_project) && input$commit_project != "all" &&
+        "project" %in% names(d)) {
+      d <- d[d$project == input$commit_project, ]
+    }
+    if (nrow(d) == 0) return(ec_empty("No data for selected repo"))
+    ec_heatmap(d, x = "iso_week", y = "project", value = "n_commits",
+               h = "350px",
+               aria_label = "Weekly commit heatmap: commit counts by week and project")
+  })
+
+  # --- Phase 2: Cost-per-Commit Trend (Cost Trends tab) ----------------------
+  output$cost_per_commit_chart <- renderUI({
+    # TODO(#27 Phase 4): wire granularity to existing time-series charts
+    if (!has_rows(cost_per_commit_data)) return(ec_empty("No cost-per-commit data available"))
+    d <- cost_per_commit_data
+    gran <- input$granularity
+    if (is.null(gran)) gran <- "weekly"
+
+    if (gran == "monthly") {
+      # Aggregate: sum cost and commits per project-month, then recompute ratio
+      d$month <- format(d$date, "%Y-%m")
+      agg_c <- aggregate(daily_cost_usd ~ project + month, data = d, FUN = sum, na.rm = TRUE)
+      agg_n <- aggregate(n_commits ~ project + month, data = d, FUN = sum, na.rm = TRUE)
+      d2 <- merge(agg_c, agg_n, by = c("project", "month"))
+      d2$cost_per_commit_usd <- ifelse(d2$n_commits > 0,
+        d2$daily_cost_usd / d2$n_commits, NA_real_)
+      d2 <- d2[!is.na(d2$cost_per_commit_usd), ]
+      x_col <- "month"
+      d2 <- d2[order(d2[[x_col]]), ]
+      xs <- sort(unique(d2[[x_col]]))
+      projects <- sort(unique(d2$project))
+      series <- lapply(projects, function(p) {
+        pd <- d2[d2$project == p, ]
+        vals <- rep(NA_real_, length(xs))
+        vals[match(pd[[x_col]], xs)] <- round(pd$cost_per_commit_usd, 2)
+        list(name = p, type = "line", data = I(vals),
+             connectNulls = TRUE)
+      })
+      ec_line(xs, series, h = "350px", y_name = "Cost per Commit ($)",
+              aria_label = "Cost per commit monthly trend by project",
+              default_window_days = 0)  # monthly labels, skip date calc
+    } else {
+      # daily or weekly: use data as-is (it is already daily)
+      d <- d[order(d$date), ]
+      d <- d[!is.na(d$cost_per_commit_usd) & is.finite(d$cost_per_commit_usd), ]
+      xs <- sort(unique(d$date))
+      projects <- sort(unique(d$project))
+      series <- lapply(projects, function(p) {
+        pd <- d[d$project == p, ]
+        vals <- rep(NA_real_, length(xs))
+        vals[match(pd$date, xs)] <- round(pd$cost_per_commit_usd, 2)
+        list(name = p, type = "line", data = I(vals),
+             connectNulls = FALSE)
+      })
+      ec_line(xs, series, h = "350px", y_name = "Cost per Commit ($)",
+              aria_label = "Cost per commit daily trend by project")
+    }
+  })
+
+  # --- Phase 2: File Churn DataTable (Git tab) --------------------------------
+  output$file_churn_table <- renderDT({
+    if (!has_rows(file_churn_data)) return(datatable(data.frame(Message = "No file churn data")))
+    d <- file_churn_data
+    # Filter to selected repo if applicable
+    if (!is.null(input$commit_project) && input$commit_project != "all" &&
+        "project" %in% names(d)) {
+      d <- d[d$project == input$commit_project, ]
+    }
+    if (nrow(d) == 0) return(datatable(data.frame(Message = "No data for selected repo")))
+    # Select display columns
+    cols <- intersect(c("project", "file", "n_commits", "total_lines_changed", "last_changed_date"),
+                      names(d))
+    out <- d[order(d$total_lines_changed, decreasing = TRUE), cols, drop = FALSE]
+    # Shorten file path for display
+    out$file <- basename(out$file)
+    datatable(out,
+      caption = "File churn by lines changed (top files per project)",
+      options = list(
+        pageLength = 15, dom = "ftip", scrollX = TRUE,
+        order = list(list(which(cols == "total_lines_changed") - 1L, "desc"))
+      ),
+      rownames = FALSE
+    )
+  })
+
+  # --- Phase 2: Change Coupling Force Graph (Git tab) -------------------------
+  output$change_coupling_graph <- renderUI({
+    if (!has_rows(change_coupling_data)) return(ec_empty("No coupling data available"))
+    d <- change_coupling_data
+    # Filter to selected repo if applicable
+    if (!is.null(input$commit_project) && input$commit_project != "all" &&
+        "project" %in% names(d)) {
+      d <- d[d$project == input$commit_project, ]
+    }
+    if (nrow(d) == 0) return(ec_empty("No coupling data for selected repo"))
+    # Cap to top 60 pairs to keep graph readable
+    d <- head(d[order(d$weight_normalised, decreasing = TRUE), ], 60)
+
+    # Build unique nodes
+    all_files <- unique(c(d$file_a, d$file_b))
+    proj_lookup <- character(length(all_files))
+    names(proj_lookup) <- all_files
+    for (f in all_files) {
+      rows_a <- d[d$file_a == f, "project"]
+      rows_b <- d[d$file_b == f, "project"]
+      proj_lookup[f] <- c(rows_a, rows_b)[1]
+    }
+    cat_map <- c("llm" = 0L, "llmtelemetry" = 1L)
+    nodes <- lapply(all_files, function(f) {
+      cat_idx <- if (!is.na(proj_lookup[f]) && proj_lookup[f] %in% names(cat_map)) {
+        cat_map[[proj_lookup[f]]]
+      } else {
+        2L
+      }
+      list(name = basename(f), value = 1,
+           symbolSize = 10,
+           category = cat_idx)
+    })
+
+    edges <- lapply(seq_len(nrow(d)), function(i) {
+      w <- d$weight_normalised[i]
+      list(source = basename(d$file_a[i]),
+           target = basename(d$file_b[i]),
+           n_cochanges = d$n_cochanges[i],
+           lineStyle = list(width = max(1, round(w * 5)),
+                            opacity = max(0.3, w)))
+    })
+
+    ec_force_graph(nodes, edges, h = "450px",
+      aria_label = "Force-directed graph: files that change together. Node = file, edge = co-change count.")
   })
 
   # --- Time Blocks ------------------------------------------------------------

--- a/vignettes/dashboard_shinylive.qmd
+++ b/vignettes/dashboard_shinylive.qmd
@@ -31,6 +31,10 @@ format:
       - data/cost_by_project_estimated.json
       - data/predictions.json
       - data/calibration_buckets.json
+      - data/weekly_commits_by_project.json
+      - data/cost_per_commit.json
+      - data/file_churn.json
+      - data/change_coupling.json
 filters:
   - shinylive
 ---
@@ -78,9 +82,21 @@ ec_empty <- function(msg = "No data available", h = "300px") {
           grid = list(containLabel = TRUE)), h, aria_label = msg)
 }
 
-ec_line <- function(dates, series, h = "300px", y_name = NULL, aria_label = "Line chart") {
+ec_line <- function(dates, series, h = "300px", y_name = NULL, aria_label = "Line chart",
+                    default_window_days = 90) {
   y_axis <- list(type = "value")
   if (!is.null(y_name)) y_axis$name <- y_name
+  # Compute dynamic dataZoom start to default to last ~3 months
+  dz_start <- 0
+  if (length(dates) > 1) {
+    d_dates <- tryCatch(as.Date(as.character(dates)), error = function(e) NULL)
+    if (!is.null(d_dates) && !all(is.na(d_dates))) {
+      total_days <- as.numeric(max(d_dates, na.rm = TRUE) - min(d_dates, na.rm = TRUE))
+      if (!is.na(total_days) && total_days > default_window_days) {
+        dz_start <- round(100 * (1 - default_window_days / total_days))
+      }
+    }
+  }
   ec(list(
     tooltip = list(trigger = "axis"),
     legend = list(bottom = 30, textStyle = list(color = "#ccc")),
@@ -90,8 +106,8 @@ ec_line <- function(dates, series, h = "300px", y_name = NULL, aria_label = "Lin
       saveAsImage = list()
     )),
     dataZoom = list(
-      list(type = "inside", start = 0, end = 100),
-      list(type = "slider", start = 0, end = 100, bottom = 5)
+      list(type = "inside", start = dz_start, end = 100),
+      list(type = "slider", start = dz_start, end = 100, bottom = 5)
     ),
     grid = list(containLabel = TRUE, bottom = 80),
     xAxis = list(type = "category", data = I(as.character(dates))),
@@ -100,9 +116,21 @@ ec_line <- function(dates, series, h = "300px", y_name = NULL, aria_label = "Lin
   ), h, aria_label = aria_label)
 }
 
-ec_bar <- function(cats, series, h = "300px", y_name = NULL, aria_label = "Bar chart") {
+ec_bar <- function(cats, series, h = "300px", y_name = NULL, aria_label = "Bar chart",
+                   default_window_days = 90) {
   y_axis <- list(type = "value")
   if (!is.null(y_name)) y_axis$name <- y_name
+  # Compute dynamic dataZoom start to default to last ~3 months
+  dz_start <- 0
+  if (length(cats) > 1) {
+    d_dates <- tryCatch(as.Date(as.character(cats)), error = function(e) NULL)
+    if (!is.null(d_dates) && !all(is.na(d_dates))) {
+      total_days <- as.numeric(max(d_dates, na.rm = TRUE) - min(d_dates, na.rm = TRUE))
+      if (!is.na(total_days) && total_days > default_window_days) {
+        dz_start <- round(100 * (1 - default_window_days / total_days))
+      }
+    }
+  }
   ec(list(
     tooltip = list(trigger = "axis"),
     legend = list(bottom = 30, textStyle = list(color = "#ccc")),
@@ -112,8 +140,8 @@ ec_bar <- function(cats, series, h = "300px", y_name = NULL, aria_label = "Bar c
       saveAsImage = list()
     )),
     dataZoom = list(
-      list(type = "inside", start = 0, end = 100),
-      list(type = "slider", start = 0, end = 100, bottom = 5)
+      list(type = "inside", start = dz_start, end = 100),
+      list(type = "slider", start = dz_start, end = 100, bottom = 5)
     ),
     grid = list(containLabel = TRUE, bottom = 80),
     xAxis = list(type = "category", data = I(as.character(cats)),
@@ -153,6 +181,101 @@ ec_scatter <- function(data_pts, color = "#377eb8", h = "300px",
       "document.getElementById('", id, "').addEventListener('click',fs);",
       "document.getElementById('", id, "').addEventListener('keydown',function(e){",
       "if(e.key==='Enter'||e.key===' '){e.preventDefault();fs()}})})();"
+    )))
+  )
+}
+
+ec_heatmap <- function(data, x, y, value, h = "350px",
+                       default_window_weeks = 13,
+                       aria_label = "Heatmap chart") {
+  # Build x/y axis labels
+  xs <- sort(unique(data[[x]]))
+  ys <- sort(unique(data[[y]]))
+  # Dynamic x-axis window: default to last ~13 weeks
+  dz_start <- 0
+  if (length(xs) > default_window_weeks) {
+    dz_start <- round(100 * (1 - default_window_weeks / length(xs)))
+  }
+  heat_data <- lapply(seq_len(nrow(data)), function(i)
+    list(match(data[[x]][i], xs) - 1L, match(data[[y]][i], ys) - 1L,
+         as.numeric(data[[value]][i])))
+  max_val <- max(as.numeric(data[[value]]), na.rm = TRUE)
+  id <- paste0("ec", sample.int(1e7, 1))
+  opt <- list(
+    tooltip = list(trigger = "item",
+      formatter = paste0("function(p){return p.value[2]+' commits at week '+",
+                         "p.value[0]+'}')")),
+    grid = list(left = 100, bottom = 80, containLabel = TRUE),
+    xAxis = list(type = "category", data = I(xs), axisLabel = list(rotate = 30)),
+    yAxis = list(type = "category", data = I(ys)),
+    dataZoom = list(
+      list(type = "inside", xAxisIndex = 0, start = dz_start, end = 100),
+      list(type = "slider", xAxisIndex = 0, start = dz_start, end = 100, bottom = 5)
+    ),
+    visualMap = list(min = 0, max = max(max_val, 1), calculable = TRUE,
+      orient = "horizontal", left = "center", top = "top",
+      inRange = list(color = I(c("#1a2a1a", "#238636", "#40c463", "#7ee787"))),
+      textStyle = list(color = "#ccc")),
+    series = list(list(
+      type = "heatmap", data = heat_data,
+      emphasis = list(itemStyle = list(shadowBlur = 10, shadowColor = "rgba(0,0,0,0.5)"))
+    ))
+  )
+  j <- toJSON(opt, auto_unbox = TRUE, null = "null")
+  tagList(
+    tags$div(id = id, class = "echart-div", role = "img",
+             `aria-label` = aria_label, tabindex = "0",
+             style = paste0("width:100%;height:", h, ";cursor:zoom-in")),
+    tags$script(HTML(paste0(
+      "(function(){var c=echarts.init(document.getElementById('", id, "'),'dark');",
+      "c.setOption(", j, ");new ResizeObserver(function(){c.resize()})",
+      ".observe(document.getElementById('", id, "'));",
+      "function fs(){var url=c.getDataURL({type:'png',pixelRatio:2,backgroundColor:'#000'});",
+      "var ov=document.createElement('div');ov.className='fullscreen-overlay';",
+      "var img=document.createElement('img');img.src=url;ov.appendChild(img);",
+      "ov.onclick=function(){ov.remove()};document.body.appendChild(ov)}",
+      "document.getElementById('", id, "').addEventListener('click',fs);",
+      "document.getElementById('", id, "').addEventListener('keydown',function(e){",
+      "if(e.key==='Enter'||e.key===' '){e.preventDefault();fs()}})})();"
+    )))
+  )
+}
+
+ec_force_graph <- function(nodes, edges, h = "400px",
+                           aria_label = "Force-directed graph") {
+  id <- paste0("ec", sample.int(1e7, 1))
+  opt <- list(
+    tooltip = list(trigger = "item",
+      formatter = "function(p){if(p.dataType==='edge')return p.data.source+' ↔ '+p.data.target+': '+p.data.n_cochanges+' co-changes'; return p.data.name}"),
+    legend = list(top = "bottom", textStyle = list(color = "#ccc")),
+    series = list(list(
+      type = "graph",
+      layout = "force",
+      force = list(repulsion = 120, gravity = 0.05, edgeLength = list(50, 150)),
+      roam = TRUE,
+      draggable = TRUE,
+      data = nodes,
+      links = edges,
+      label = list(show = TRUE, position = "right", color = "#ccc", fontSize = 10),
+      lineStyle = list(color = "source", curveness = 0.1),
+      categories = list(
+        list(name = "llm", itemStyle = list(color = "#377eb8")),
+        list(name = "llmtelemetry", itemStyle = list(color = "#e41a1c")),
+        list(name = "other", itemStyle = list(color = "#4daf4a"))
+      ),
+      emphasis = list(focus = "adjacency",
+        lineStyle = list(width = 4))
+    ))
+  )
+  j <- toJSON(opt, auto_unbox = TRUE, null = "null")
+  tagList(
+    tags$div(id = id, class = "echart-div", role = "img",
+             `aria-label` = aria_label, tabindex = "0",
+             style = paste0("width:100%;height:", h, ";cursor:zoom-in")),
+    tags$script(HTML(paste0(
+      "(function(){var c=echarts.init(document.getElementById('", id, "'),'dark');",
+      "c.setOption(", j, ");new ResizeObserver(function(){c.resize()})",
+      ".observe(document.getElementById('", id, "'))})();"
     )))
   )
 }
@@ -197,11 +320,20 @@ git_todo    <- load_json("git_todo.json")
 git_tags    <- load_json("git_tags.json")
 git_file_growth <- load_json("git_file_growth.json")
 gh_events   <- load_json("github_issue_events.json")
+# Phase 2 data: new analytical JSON exports
+weekly_commits <- load_json("weekly_commits_by_project.json")
+cost_per_commit_data <- load_json("cost_per_commit.json")
+file_churn_data <- load_json("file_churn.json")
+change_coupling_data <- load_json("change_coupling.json")
 
 # Normalize data: fromJSON("[]") returns list(), nested objects need extraction
 as_df <- function(x) if (is.data.frame(x)) x else NULL
 git_file_growth <- as_df(git_file_growth)
 gh_events <- as_df(gh_events)
+weekly_commits <- as_df(weekly_commits)
+cost_per_commit_data <- as_df(cost_per_commit_data)
+file_churn_data <- as_df(file_churn_data)
+change_coupling_data <- as_df(change_coupling_data)
 has_rows <- function(x) is.data.frame(x) && nrow(x) > 0
 
 # Shorten project path: keep last 2 meaningful segments
@@ -347,6 +479,10 @@ if (has_rows(u_sessions)) {
   u_sessions$started_at <- as.POSIXct(u_sessions$started_at, tz = "UTC")
 }
 if (has_rows(u_costs)) u_costs$date <- as.Date(u_costs$date)
+if (has_rows(cost_per_commit_data)) cost_per_commit_data$date <- as.Date(cost_per_commit_data$date)
+if (has_rows(file_churn_data) && "last_changed_date" %in% names(file_churn_data)) {
+  file_churn_data$last_changed_date <- as.Date(file_churn_data$last_changed_date)
+}
 if (has_rows(gem_sess)) {
   gem_sess$start_time <- as.POSIXct(gem_sess$start_time, tz = "UTC")
   gem_sess$date <- as.Date(gem_sess$start_time)


### PR DESCRIPTION
## Summary
Phase 3 of #27. UI refresh of `dashboard_shinylive.qmd` consuming the Phase 2 data exports.

## Changes
- **ec_line / ec_bar helpers:** dynamic `dataZoom.start` defaulting to last ~90 days
- **Granularity toggle** in sidebar (daily/weekly/monthly, weekly default) — wired to new charts
- **value_box → compact tables:** 10 value_boxes collapsed into 3 summary cards (Overview, Sessions, Git)
- **New charts:**
  - Weekly commit heatmap (By Project tab)
  - Cost-per-commit trend (Cost Trends tab)
  - File churn DataTable (Git tab)
  - Change-coupling force-directed graph (Git tab)

## Verification
- [x] Dashboard renders without error
- [x] Existing tests pass (152/152)
- [x] Dark-contrast script passes (no light inline backgrounds)
- [ ] Browser walkthrough (orchestrator / user)

Part of #27. Phase 4 (polish) to follow.