### PR TITLE
fix(qa): grep rendered HTML for error patterns (closes-some #69)

### DIFF
--- a/.github/workflows/deploy-dashboard.yaml
+++ b/.github/workflows/deploy-dashboard.yaml
@@ -250,6 +250,25 @@ jobs:
               fi
             fi
           fi
+          # Check rendered HTML for known error patterns (issue #69)
+          echo "=== Checking rendered HTML for error patterns ==="
+          HTML=$(curl -sf "${BASE}/" 2>/dev/null || echo "")
+          for pat in "no method" "S3 class:" "could not find function"; do
+            if echo "$HTML" | grep -iqE "$pat"; then
+              MATCH=$(echo "$HTML" | grep -inE "$pat" | head -1)
+              echo "::error::Dashboard HTML contains error pattern '$pat': $MATCH"
+              FAIL=1
+            fi
+          done
+          # Also check the dashboard_shinylive.html directly in case root is a different page
+          DASH_HTML=$(curl -sf "${BASE}/dashboard_shinylive.html" 2>/dev/null || echo "")
+          for pat in "no method" "S3 class:" "could not find function"; do
+            if echo "$DASH_HTML" | grep -iqE "$pat"; then
+              MATCH=$(echo "$DASH_HTML" | grep -inE "$pat" | head -1)
+              echo "::error::dashboard_shinylive.html contains error pattern '$pat': $MATCH"
+              FAIL=1
+            fi
+          done
           if [ "$FAIL" = "1" ]; then
             echo "::warning::Some deployment health checks failed — inspect logs"
           else

--- a/inst/scripts/qa_dashboard_content.sh
+++ b/inst/scripts/qa_dashboard_content.sh
@@ -24,6 +24,24 @@ fi
 
 echo "Fetched $(wc -c < "$TMP" | tr -d ' ') bytes"
 
+# --- Check rendered HTML for known error patterns (issue #69) ---
+echo ""
+echo "=== Checking rendered HTML for error patterns ==="
+ERROR_PATTERNS=(
+  "no method"
+  "S3 class:"
+  "could not find function"
+  "object .* not found"
+)
+for pat in "${ERROR_PATTERNS[@]}"; do
+  if grep -iqE "$pat" "$TMP"; then
+    MATCH=$(grep -inE "$pat" "$TMP" | head -1)
+    echo "FAIL: rendered HTML contains error pattern '$pat'"
+    echo "  Match: $MATCH"
+    ERRORS=$((ERRORS + 1))
+  fi
+done
+
 # --- Check data JSON files directly ---
 DATA_URL="${URL%/}/data"
 declare -a CRITICAL_DATA=(


### PR DESCRIPTION
## Summary
The dashboard QA never inspected the rendered HTML for visible error strings — so the "Cost Share by Date" chart rendering `No method asJSON S3 class: JS_EVAL` instead of a heatmap passed all checks and shipped to gh-pages. This PR adds grep for known R-rendered-error patterns in two places so the pipeline fails before publish AND the live-URL check fails after.

## Changes

### `inst/scripts/qa_dashboard_content.sh` (+18)
After the HTML is already fetched to `$TMP`, grep it for known error patterns. Increment `$ERRORS` on any match → script exits non-zero before publish.

### `.github/workflows/deploy-dashboard.yaml` (+19)
In the "Verify deployment" step, after the staleness checks, fetch both `${BASE}/` and `${BASE}/dashboard_shinylive.html`, grep for the same patterns, set `FAIL=1` on match. Emits `::error::` so GitHub Actions surfaces it.

## Patterns caught
- `no method` (catches asJSON S3 dispatch failures)
- `S3 class:` (related)
- `could not find function` (NSE / missing functions)
- `object .* not found` (only in local script; CI script's inline `for` would need escaping)

## Test plan
- [ ] CI passes on this branch
- [ ] Locally render a doc containing the literal `No method asJSON S3 class: JS_EVAL` → expect `qa_dashboard_content.sh` to exit non-zero
- [ ] After merge, the next deploy-dashboard CI run greps the live URL

## Related
- #69 — the bug class that motivated this (B4 finding from browser walkthrough)
- Browser walkthrough of PR #67 surfaced the gap