### PR TITLE
feat(#83): Phase 2A — DuckDB-WASM pilot querying real v1 parquet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ full refresh history.
 
 ## [Unreleased]
 
+### Phase 2A of epic #83 (DRAFT PR)
+- `vignettes/dashboard_v1_pilot.qmd`: pilot demonstrating DuckDB-WASM querying real v1 sessions parquet (329 rows) rendered to ECharts horizontal bar chart — pure JS, no R reactivity
+- `.gitignore`: `vignettes/data/` already excluded (served copies are not source-of-truth)
+- `scripts/serve_pilot.sh`: convenience runner — copies parquet, starts python3 http.server on port 8900
+- Phase 2B will integrate this pattern into the main dashboard with project-filter reactivity
+
 ### Phase 1F of epic #83 (PR #N)
 - Refactor: `.canonicalize_project_local()` moved to `R/canonicalize.R` as shared internal helper (used by all 3 appenders)
 - New function: `append_costs_from_staging()` — consumes `cost_emitted` events into v1 costs parquet; dedup by `cost_id = paste(canonical_project, date, source, sep="|")`

--- a/scripts/serve_pilot.sh
+++ b/scripts/serve_pilot.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# serve_pilot.sh — copy parquet + serve the Phase 2A pilot HTML locally
+# Usage: bash scripts/serve_pilot.sh [PORT]
+# Default port: 8900
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PORT="${1:-8900}"
+
+echo "[serve_pilot] Copying parquet to vignettes/data/v1/ ..."
+mkdir -p "${REPO_ROOT}/vignettes/data/v1"
+cp "${REPO_ROOT}/inst/extdata/telemetry/v1/sessions.parquet" \
+   "${REPO_ROOT}/vignettes/data/v1/sessions.parquet"
+echo "[serve_pilot] Copied sessions.parquet ($(du -sh "${REPO_ROOT}/vignettes/data/v1/sessions.parquet" | cut -f1))"
+
+echo "[serve_pilot] Serving ${REPO_ROOT}/vignettes/ on http://localhost:${PORT}"
+echo "[serve_pilot] Open: http://localhost:${PORT}/dashboard_v1_pilot.html"
+echo "[serve_pilot] Press Ctrl-C to stop."
+python3 -m http.server "${PORT}" --directory "${REPO_ROOT}/vignettes"

--- a/vignettes/dashboard_v1_pilot.html
+++ b/vignettes/dashboard_v1_pilot.html
@@ -1,0 +1,696 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head>
+
+<meta charset="utf-8">
+<meta name="generator" content="quarto-1.8.26">
+
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+
+
+<title>v1 Telemetry — DuckDB-WASM Pilot (Phase 2A)</title>
+<style>
+code{white-space: pre-wrap;}
+span.smallcaps{font-variant: small-caps;}
+div.columns{display: flex; gap: min(4vw, 1.5em);}
+div.column{flex: auto; overflow-x: auto;}
+div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+ul.task-list{list-style: none;}
+ul.task-list li input[type="checkbox"] {
+  width: 0.8em;
+  margin: 0 0.8em 0.2em -1em; /* quarto-specific, see https://github.com/quarto-dev/quarto-cli/issues/4556 */ 
+  vertical-align: middle;
+}
+/* CSS for syntax highlighting */
+html { -webkit-text-size-adjust: 100%; }
+pre > code.sourceCode { white-space: pre; position: relative; }
+pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
+pre > code.sourceCode > span:empty { height: 1.2em; }
+.sourceCode { overflow: visible; }
+code.sourceCode > span { color: inherit; text-decoration: inherit; }
+div.sourceCode { margin: 1em 0; }
+pre.sourceCode { margin: 0; }
+@media screen {
+div.sourceCode { overflow: auto; }
+}
+@media print {
+pre > code.sourceCode { white-space: pre-wrap; }
+pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
+}
+pre.numberSource code
+  { counter-reset: source-line 0; }
+pre.numberSource code > span
+  { position: relative; left: -4em; counter-increment: source-line; }
+pre.numberSource code > span > a:first-child::before
+  { content: counter(source-line);
+    position: relative; left: -1em; text-align: right; vertical-align: baseline;
+    border: none; display: inline-block;
+    -webkit-touch-callout: none; -webkit-user-select: none;
+    -khtml-user-select: none; -moz-user-select: none;
+    -ms-user-select: none; user-select: none;
+    padding: 0 4px; width: 4em;
+  }
+pre.numberSource { margin-left: 3em;  padding-left: 4px; }
+div.sourceCode
+  {   }
+@media screen {
+pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
+}
+</style>
+
+
+<script src="dashboard_v1_pilot_files/libs/clipboard/clipboard.min.js"></script>
+<script src="dashboard_v1_pilot_files/libs/quarto-html/quarto.js" type="module"></script>
+<script src="dashboard_v1_pilot_files/libs/quarto-html/tabsets/tabsets.js" type="module"></script>
+<script src="dashboard_v1_pilot_files/libs/quarto-html/axe/axe-check.js" type="module"></script>
+<script src="dashboard_v1_pilot_files/libs/quarto-html/popper.min.js"></script>
+<script src="dashboard_v1_pilot_files/libs/quarto-html/tippy.umd.min.js"></script>
+<script src="dashboard_v1_pilot_files/libs/quarto-html/anchor.min.js"></script>
+<link href="dashboard_v1_pilot_files/libs/quarto-html/tippy.css" rel="stylesheet">
+<link href="dashboard_v1_pilot_files/libs/quarto-html/quarto-syntax-highlighting-587c61ba64f3a5504c4d52d930310e48.css" rel="stylesheet" id="quarto-text-highlighting-styles">
+<script src="dashboard_v1_pilot_files/libs/bootstrap/bootstrap.min.js"></script>
+<link href="dashboard_v1_pilot_files/libs/bootstrap/bootstrap-icons.css" rel="stylesheet">
+<link href="dashboard_v1_pilot_files/libs/bootstrap/bootstrap-d5fa03fb90ac27921a6d47853be462c0.min.css" rel="stylesheet" append-hash="true" id="quarto-bootstrap" data-mode="light">
+
+
+</head>
+
+<body class="fullcontent quarto-light">
+
+<div id="quarto-content" class="page-columns page-rows-contents page-layout-article">
+
+<main class="content" id="quarto-document-content">
+
+<header id="title-block-header" class="quarto-title-block default">
+<div class="quarto-title">
+<h1 class="title">v1 Telemetry — DuckDB-WASM Pilot (Phase 2A)</h1>
+</div>
+
+
+
+<div class="quarto-title-meta">
+
+    
+  
+    
+  </div>
+  
+
+
+</header>
+
+
+<section id="what-this-shows" class="level2">
+<h2 class="anchored" data-anchor-id="what-this-shows">What this shows</h2>
+<p>End-to-end demo: real v1 sessions parquet (329 rows from Phase 1A) fetched and queried by DuckDB-WASM in the browser, rendered to an ECharts bar chart.</p>
+<p>No R reactivity yet. Pure JS pipeline: parquet → DuckDB-WASM (in Web Worker) → JS rowset → ECharts.</p>
+<p>Verifies the architecture works against REAL telemetry data, not just a fixture.</p>
+</section>
+<section id="how-to-test-locally" class="level2">
+<h2 class="anchored" data-anchor-id="how-to-test-locally">How to test locally</h2>
+<div class="code-copy-outer-scaffold"><div class="sourceCode" id="cb1"><pre class="sourceCode bash code-with-copy"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="co"># 1. Copy the parquet next to the served HTML</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="fu">mkdir</span> <span class="at">-p</span> vignettes/data/v1</span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="fu">cp</span> inst/extdata/telemetry/v1/sessions.parquet vignettes/data/v1/sessions.parquet</span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a><span class="co"># 2. Render</span></span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a><span class="ex">quarto</span> render vignettes/dashboard_v1_pilot.qmd</span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-8"><a href="#cb1-8" aria-hidden="true" tabindex="-1"></a><span class="co"># 3. Serve (convenience wrapper)</span></span>
+<span id="cb1-9"><a href="#cb1-9" aria-hidden="true" tabindex="-1"></a><span class="fu">bash</span> scripts/serve_pilot.sh</span>
+<span id="cb1-10"><a href="#cb1-10" aria-hidden="true" tabindex="-1"></a><span class="co"># OR manually:</span></span>
+<span id="cb1-11"><a href="#cb1-11" aria-hidden="true" tabindex="-1"></a><span class="ex">python3</span> <span class="at">-m</span> http.server 8900 <span class="at">--directory</span> vignettes</span>
+<span id="cb1-12"><a href="#cb1-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-13"><a href="#cb1-13" aria-hidden="true" tabindex="-1"></a><span class="co"># 4. Open http://localhost:8900/dashboard_v1_pilot.html</span></span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+</section>
+<section id="sessions-per-canonical_project-last-30-days" class="level2">
+<h2 class="anchored" data-anchor-id="sessions-per-canonical_project-last-30-days">Sessions per canonical_project (last 30 days)</h2>
+<div id="status" style="background:#1a1a1a; color:#0f0; padding:0.8em; font-family:monospace; font-size:0.85em; margin-bottom:0.5em;">
+Loading DuckDB-WASM…
+</div>
+<div id="chart" style="width:100%; height:400px; background:#1a1a1a; border-radius:4px;">
+
+</div>
+<script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
+<script type="module">
+  const statusDiv = document.getElementById('status');
+  const chartDiv  = document.getElementById('chart');
+  const t0 = performance.now();
+  const ms = () => `[${Math.round(performance.now() - t0)}ms]`;
+  const log = msg => { statusDiv.textContent += '\n' + msg; };
+
+  try {
+    // ── 1. Import DuckDB-WASM (version locked to 1.32.0 — proven in Phase 0) ──
+    const duckdb = await import('https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.32.0/+esm');
+    log(`${ms()} DuckDB-WASM module imported`);
+
+    const JSDELIVR_BUNDLES = duckdb.getJsDelivrBundles();
+    const bundle = await duckdb.selectBundle(JSDELIVR_BUNDLES);
+    log(`${ms()} Bundle selected: ${bundle.mainModule}`);
+
+    const worker_url = URL.createObjectURL(
+      new Blob([`importScripts("${bundle.mainWorker}");`], { type: 'text/javascript' })
+    );
+    const worker = new Worker(worker_url);
+    const logger = new duckdb.ConsoleLogger();
+    const db     = new duckdb.AsyncDuckDB(logger, worker);
+    await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
+    URL.revokeObjectURL(worker_url);
+    log(`${ms()} DuckDB instantiated`);
+
+    const conn = await db.connect();
+    log(`${ms()} Connection established`);
+
+    // ── 2. Register parquet into DuckDB-WASM virtual filesystem ──
+    // File must be same-origin (served by the local http.server).
+    // Path is relative to the vignettes/ serve root.
+    const parquet_url = new URL('data/v1/sessions.parquet', window.location.href).href;
+    await db.registerFileURL(
+      'sessions.parquet',
+      parquet_url,
+      duckdb.DuckDBDataProtocol.HTTP,
+      false  // direct IO (range requests if server supports them)
+    );
+    log(`${ms()} Registered sessions.parquet -> ${parquet_url}`);
+
+    // ── 3. Query: sessions per canonical_project, last 30 days ──
+    // canonical_project IS NOT NULL filters the 136 NULL-project rows.
+    const result = await conn.query(`
+      SELECT
+        canonical_project,
+        COUNT(*) AS n_sessions
+      FROM 'sessions.parquet'
+      WHERE canonical_project IS NOT NULL
+        AND started_at >= NOW() - INTERVAL '30 days'
+      GROUP BY canonical_project
+      ORDER BY n_sessions DESC
+    `);
+
+    // Arrow BigInt → plain number for ECharts
+    const rows = result.toArray().map(r =>
+      Object.fromEntries(
+        Object.entries(r).map(([k, v]) => [k, typeof v === 'bigint' ? Number(v) : v])
+      )
+    );
+    log(`${ms()} Query returned ${rows.length} projects (last 30 days)`);
+
+    await conn.close();
+    const elapsed = Math.round(performance.now() - t0);
+    log(`${ms()} Connection closed — total: ${elapsed}ms`);
+    statusDiv.style.color = rows.length > 0 ? '#0f0' : '#ff0';
+
+    // ── 4. Render ECharts bar chart ──
+    const projects    = rows.map(r => r.canonical_project);
+    const sessionCounts = rows.map(r => r.n_sessions);
+
+    const chart = echarts.init(chartDiv, 'dark');
+    chart.setOption({
+      backgroundColor: '#1a1a1a',
+      tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+      grid:    { left: '3%', right: '4%', bottom: '3%', containLabel: true },
+      xAxis: {
+        type: 'value',
+        name: 'Sessions',
+        nameLocation: 'middle',
+        nameGap: 30,
+        axisLabel: { color: '#ccc' },
+        nameTextStyle: { color: '#ccc' }
+      },
+      yAxis: {
+        type: 'category',
+        data: projects.slice().reverse(),   // highest at top
+        axisLabel: { color: '#ccc', fontSize: 12 }
+      },
+      series: [{
+        name: 'Sessions',
+        type: 'bar',
+        data: sessionCounts.slice().reverse(),
+        itemStyle: { color: '#4ea8de' },
+        label: {
+          show: true,
+          position: 'right',
+          color: '#ccc',
+          formatter: '{c}'
+        }
+      }]
+    });
+
+    // Responsive resize
+    window.addEventListener('resize', () => chart.resize());
+
+  } catch (e) {
+    statusDiv.textContent += `\n\nERROR: ${e.message}\n${e.stack || ''}`;
+    statusDiv.style.color = '#f55';
+    console.error(e);
+  }
+</script>
+</section>
+<section id="verification" class="level2">
+<h2 class="anchored" data-anchor-id="verification">Verification</h2>
+<p>After rendering and opening locally, you should see:</p>
+<ul>
+<li>Status div: green text showing load timings (target: &lt; 1.5 s cold load)</li>
+<li>Chart: horizontal bar chart with canonical_project on y-axis, session count on x-axis</li>
+<li>DevTools Network tab: ONE fetch of <code>data/v1/sessions.parquet</code>, status 200</li>
+</ul>
+</section>
+<section id="what-this-proves" class="level2">
+<h2 class="anchored" data-anchor-id="what-this-proves">What this proves</h2>
+<ul>
+<li>DuckDB-WASM successfully queries a real Phase 1 v1 parquet file</li>
+<li>ECharts renders the result without any R-side participation</li>
+<li>Pattern is ready to scale to the main dashboard (Phase 2B, separate PR)</li>
+</ul>
+</section>
+<section id="what-is-not-proven-yet-phase-2b-and-beyond" class="level2">
+<h2 class="anchored" data-anchor-id="what-is-not-proven-yet-phase-2b-and-beyond">What is NOT proven yet (Phase 2B and beyond)</h2>
+<ul>
+<li>Reactivity: chart does not update when sidebar inputs change</li>
+<li>Deploy: gh-pages CI workflow does not yet copy parquet to <code>_site/data/v1/</code></li>
+<li>Multiple charts on one page sharing a single DuckDB connection</li>
+</ul>
+</section>
+<section id="methodology" class="level2">
+<h2 class="anchored" data-anchor-id="methodology">Methodology</h2>
+<section id="what-this-vignette-computes" class="level3">
+<h3 class="anchored" data-anchor-id="what-this-vignette-computes">What this vignette computes</h3>
+<p>Reads <code>inst/extdata/telemetry/v1/sessions.parquet</code> (329 rows, produced by Phase 1A of epic #83) directly in the browser via DuckDB-WASM. Counts sessions per <code>canonical_project</code> over the last 30 days and renders the result as an ECharts horizontal bar chart. No targets pipeline involved — this is a pure-JS pilot.</p>
+</section>
+<section id="data-sources" class="level3">
+<h3 class="anchored" data-anchor-id="data-sources">Data sources</h3>
+<ul>
+<li><code>inst/extdata/telemetry/v1/sessions.parquet</code>: v1 sessions parquet written by the Phase 1A targets pipeline; served from <code>vignettes/data/v1/</code> at local test time via <code>python3 -m http.server</code></li>
+</ul>
+</section>
+<section id="ai-disclosure" class="level3">
+<h3 class="anchored" data-anchor-id="ai-disclosure">AI disclosure</h3>
+<p>This vignette was developed with assistance from Anthropic’s Claude (model: Opus 4.7 and Sonnet 4.6). AI helped with code structure, prose drafting, and visualization choices. All analytical decisions and data interpretations are the author’s responsibility.</p>
+</section>
+</section>
+
+</main>
+<!-- /main column -->
+<script id="quarto-html-after-body" type="application/javascript">
+  window.document.addEventListener("DOMContentLoaded", function (event) {
+    const icon = "";
+    const anchorJS = new window.AnchorJS();
+    anchorJS.options = {
+      placement: 'right',
+      icon: icon
+    };
+    anchorJS.add('.anchored');
+    const isCodeAnnotation = (el) => {
+      for (const clz of el.classList) {
+        if (clz.startsWith('code-annotation-')) {                     
+          return true;
+        }
+      }
+      return false;
+    }
+    const onCopySuccess = function(e) {
+      // button target
+      const button = e.trigger;
+      // don't keep focus
+      button.blur();
+      // flash "checked"
+      button.classList.add('code-copy-button-checked');
+      var currentTitle = button.getAttribute("title");
+      button.setAttribute("title", "Copied!");
+      let tooltip;
+      if (window.bootstrap) {
+        button.setAttribute("data-bs-toggle", "tooltip");
+        button.setAttribute("data-bs-placement", "left");
+        button.setAttribute("data-bs-title", "Copied!");
+        tooltip = new bootstrap.Tooltip(button, 
+          { trigger: "manual", 
+            customClass: "code-copy-button-tooltip",
+            offset: [0, -8]});
+        tooltip.show();    
+      }
+      setTimeout(function() {
+        if (tooltip) {
+          tooltip.hide();
+          button.removeAttribute("data-bs-title");
+          button.removeAttribute("data-bs-toggle");
+          button.removeAttribute("data-bs-placement");
+        }
+        button.setAttribute("title", currentTitle);
+        button.classList.remove('code-copy-button-checked');
+      }, 1000);
+      // clear code selection
+      e.clearSelection();
+    }
+    const getTextToCopy = function(trigger) {
+      const outerScaffold = trigger.parentElement.cloneNode(true);
+      const codeEl = outerScaffold.querySelector('code');
+      for (const childEl of codeEl.children) {
+        if (isCodeAnnotation(childEl)) {
+          childEl.remove();
+        }
+      }
+      return codeEl.innerText;
+    }
+    const clipboard = new window.ClipboardJS('.code-copy-button:not([data-in-quarto-modal])', {
+      text: getTextToCopy
+    });
+    clipboard.on('success', onCopySuccess);
+    if (window.document.getElementById('quarto-embedded-source-code-modal')) {
+      const clipboardModal = new window.ClipboardJS('.code-copy-button[data-in-quarto-modal]', {
+        text: getTextToCopy,
+        container: window.document.getElementById('quarto-embedded-source-code-modal')
+      });
+      clipboardModal.on('success', onCopySuccess);
+    }
+      var localhostRegex = new RegExp(/^(?:http|https):\/\/localhost\:?[0-9]*\//);
+      var mailtoRegex = new RegExp(/^mailto:/);
+        var filterRegex = new RegExp('/' + window.location.host + '/');
+      var isInternal = (href) => {
+          return filterRegex.test(href) || localhostRegex.test(href) || mailtoRegex.test(href);
+      }
+      // Inspect non-navigation links and adorn them if external
+     var links = window.document.querySelectorAll('a[href]:not(.nav-link):not(.navbar-brand):not(.toc-action):not(.sidebar-link):not(.sidebar-item-toggle):not(.pagination-link):not(.no-external):not([aria-hidden]):not(.dropdown-item):not(.quarto-navigation-tool):not(.about-link)');
+      for (var i=0; i<links.length; i++) {
+        const link = links[i];
+        if (!isInternal(link.href)) {
+          // undo the damage that might have been done by quarto-nav.js in the case of
+          // links that we want to consider external
+          if (link.dataset.originalHref !== undefined) {
+            link.href = link.dataset.originalHref;
+          }
+        }
+      }
+    function tippyHover(el, contentFn, onTriggerFn, onUntriggerFn) {
+      const config = {
+        allowHTML: true,
+        maxWidth: 500,
+        delay: 100,
+        arrow: false,
+        appendTo: function(el) {
+            return el.parentElement;
+        },
+        interactive: true,
+        interactiveBorder: 10,
+        theme: 'quarto',
+        placement: 'bottom-start',
+      };
+      if (contentFn) {
+        config.content = contentFn;
+      }
+      if (onTriggerFn) {
+        config.onTrigger = onTriggerFn;
+      }
+      if (onUntriggerFn) {
+        config.onUntrigger = onUntriggerFn;
+      }
+      window.tippy(el, config); 
+    }
+    const noterefs = window.document.querySelectorAll('a[role="doc-noteref"]');
+    for (var i=0; i<noterefs.length; i++) {
+      const ref = noterefs[i];
+      tippyHover(ref, function() {
+        // use id or data attribute instead here
+        let href = ref.getAttribute('data-footnote-href') || ref.getAttribute('href');
+        try { href = new URL(href).hash; } catch {}
+        const id = href.replace(/^#\/?/, "");
+        const note = window.document.getElementById(id);
+        if (note) {
+          return note.innerHTML;
+        } else {
+          return "";
+        }
+      });
+    }
+    const xrefs = window.document.querySelectorAll('a.quarto-xref');
+    const processXRef = (id, note) => {
+      // Strip column container classes
+      const stripColumnClz = (el) => {
+        el.classList.remove("page-full", "page-columns");
+        if (el.children) {
+          for (const child of el.children) {
+            stripColumnClz(child);
+          }
+        }
+      }
+      stripColumnClz(note)
+      if (id === null || id.startsWith('sec-')) {
+        // Special case sections, only their first couple elements
+        const container = document.createElement("div");
+        if (note.children && note.children.length > 2) {
+          container.appendChild(note.children[0].cloneNode(true));
+          for (let i = 1; i < note.children.length; i++) {
+            const child = note.children[i];
+            if (child.tagName === "P" && child.innerText === "") {
+              continue;
+            } else {
+              container.appendChild(child.cloneNode(true));
+              break;
+            }
+          }
+          if (window.Quarto?.typesetMath) {
+            window.Quarto.typesetMath(container);
+          }
+          return container.innerHTML
+        } else {
+          if (window.Quarto?.typesetMath) {
+            window.Quarto.typesetMath(note);
+          }
+          return note.innerHTML;
+        }
+      } else {
+        // Remove any anchor links if they are present
+        const anchorLink = note.querySelector('a.anchorjs-link');
+        if (anchorLink) {
+          anchorLink.remove();
+        }
+        if (window.Quarto?.typesetMath) {
+          window.Quarto.typesetMath(note);
+        }
+        if (note.classList.contains("callout")) {
+          return note.outerHTML;
+        } else {
+          return note.innerHTML;
+        }
+      }
+    }
+    for (var i=0; i<xrefs.length; i++) {
+      const xref = xrefs[i];
+      tippyHover(xref, undefined, function(instance) {
+        instance.disable();
+        let url = xref.getAttribute('href');
+        let hash = undefined; 
+        if (url.startsWith('#')) {
+          hash = url;
+        } else {
+          try { hash = new URL(url).hash; } catch {}
+        }
+        if (hash) {
+          const id = hash.replace(/^#\/?/, "");
+          const note = window.document.getElementById(id);
+          if (note !== null) {
+            try {
+              const html = processXRef(id, note.cloneNode(true));
+              instance.setContent(html);
+            } finally {
+              instance.enable();
+              instance.show();
+            }
+          } else {
+            // See if we can fetch this
+            fetch(url.split('#')[0])
+            .then(res => res.text())
+            .then(html => {
+              const parser = new DOMParser();
+              const htmlDoc = parser.parseFromString(html, "text/html");
+              const note = htmlDoc.getElementById(id);
+              if (note !== null) {
+                const html = processXRef(id, note);
+                instance.setContent(html);
+              } 
+            }).finally(() => {
+              instance.enable();
+              instance.show();
+            });
+          }
+        } else {
+          // See if we can fetch a full url (with no hash to target)
+          // This is a special case and we should probably do some content thinning / targeting
+          fetch(url)
+          .then(res => res.text())
+          .then(html => {
+            const parser = new DOMParser();
+            const htmlDoc = parser.parseFromString(html, "text/html");
+            const note = htmlDoc.querySelector('main.content');
+            if (note !== null) {
+              // This should only happen for chapter cross references
+              // (since there is no id in the URL)
+              // remove the first header
+              if (note.children.length > 0 && note.children[0].tagName === "HEADER") {
+                note.children[0].remove();
+              }
+              const html = processXRef(null, note);
+              instance.setContent(html);
+            } 
+          }).finally(() => {
+            instance.enable();
+            instance.show();
+          });
+        }
+      }, function(instance) {
+      });
+    }
+        let selectedAnnoteEl;
+        const selectorForAnnotation = ( cell, annotation) => {
+          let cellAttr = 'data-code-cell="' + cell + '"';
+          let lineAttr = 'data-code-annotation="' +  annotation + '"';
+          const selector = 'span[' + cellAttr + '][' + lineAttr + ']';
+          return selector;
+        }
+        const selectCodeLines = (annoteEl) => {
+          const doc = window.document;
+          const targetCell = annoteEl.getAttribute("data-target-cell");
+          const targetAnnotation = annoteEl.getAttribute("data-target-annotation");
+          const annoteSpan = window.document.querySelector(selectorForAnnotation(targetCell, targetAnnotation));
+          const lines = annoteSpan.getAttribute("data-code-lines").split(",");
+          const lineIds = lines.map((line) => {
+            return targetCell + "-" + line;
+          })
+          let top = null;
+          let height = null;
+          let parent = null;
+          if (lineIds.length > 0) {
+              //compute the position of the single el (top and bottom and make a div)
+              const el = window.document.getElementById(lineIds[0]);
+              top = el.offsetTop;
+              height = el.offsetHeight;
+              parent = el.parentElement.parentElement;
+            if (lineIds.length > 1) {
+              const lastEl = window.document.getElementById(lineIds[lineIds.length - 1]);
+              const bottom = lastEl.offsetTop + lastEl.offsetHeight;
+              height = bottom - top;
+            }
+            if (top !== null && height !== null && parent !== null) {
+              // cook up a div (if necessary) and position it 
+              let div = window.document.getElementById("code-annotation-line-highlight");
+              if (div === null) {
+                div = window.document.createElement("div");
+                div.setAttribute("id", "code-annotation-line-highlight");
+                div.style.position = 'absolute';
+                parent.appendChild(div);
+              }
+              div.style.top = top - 2 + "px";
+              div.style.height = height + 4 + "px";
+              div.style.left = 0;
+              let gutterDiv = window.document.getElementById("code-annotation-line-highlight-gutter");
+              if (gutterDiv === null) {
+                gutterDiv = window.document.createElement("div");
+                gutterDiv.setAttribute("id", "code-annotation-line-highlight-gutter");
+                gutterDiv.style.position = 'absolute';
+                const codeCell = window.document.getElementById(targetCell);
+                const gutter = codeCell.querySelector('.code-annotation-gutter');
+                gutter.appendChild(gutterDiv);
+              }
+              gutterDiv.style.top = top - 2 + "px";
+              gutterDiv.style.height = height + 4 + "px";
+            }
+            selectedAnnoteEl = annoteEl;
+          }
+        };
+        const unselectCodeLines = () => {
+          const elementsIds = ["code-annotation-line-highlight", "code-annotation-line-highlight-gutter"];
+          elementsIds.forEach((elId) => {
+            const div = window.document.getElementById(elId);
+            if (div) {
+              div.remove();
+            }
+          });
+          selectedAnnoteEl = undefined;
+        };
+          // Handle positioning of the toggle
+      window.addEventListener(
+        "resize",
+        throttle(() => {
+          elRect = undefined;
+          if (selectedAnnoteEl) {
+            selectCodeLines(selectedAnnoteEl);
+          }
+        }, 10)
+      );
+      function throttle(fn, ms) {
+      let throttle = false;
+      let timer;
+        return (...args) => {
+          if(!throttle) { // first call gets through
+              fn.apply(this, args);
+              throttle = true;
+          } else { // all the others get throttled
+              if(timer) clearTimeout(timer); // cancel #2
+              timer = setTimeout(() => {
+                fn.apply(this, args);
+                timer = throttle = false;
+              }, ms);
+          }
+        };
+      }
+        // Attach click handler to the DT
+        const annoteDls = window.document.querySelectorAll('dt[data-target-cell]');
+        for (const annoteDlNode of annoteDls) {
+          annoteDlNode.addEventListener('click', (event) => {
+            const clickedEl = event.target;
+            if (clickedEl !== selectedAnnoteEl) {
+              unselectCodeLines();
+              const activeEl = window.document.querySelector('dt[data-target-cell].code-annotation-active');
+              if (activeEl) {
+                activeEl.classList.remove('code-annotation-active');
+              }
+              selectCodeLines(clickedEl);
+              clickedEl.classList.add('code-annotation-active');
+            } else {
+              // Unselect the line
+              unselectCodeLines();
+              clickedEl.classList.remove('code-annotation-active');
+            }
+          });
+        }
+    const findCites = (el) => {
+      const parentEl = el.parentElement;
+      if (parentEl) {
+        const cites = parentEl.dataset.cites;
+        if (cites) {
+          return {
+            el,
+            cites: cites.split(' ')
+          };
+        } else {
+          return findCites(el.parentElement)
+        }
+      } else {
+        return undefined;
+      }
+    };
+    var bibliorefs = window.document.querySelectorAll('a[role="doc-biblioref"]');
+    for (var i=0; i<bibliorefs.length; i++) {
+      const ref = bibliorefs[i];
+      const citeInfo = findCites(ref);
+      if (citeInfo) {
+        tippyHover(citeInfo.el, function() {
+          var popup = window.document.createElement('div');
+          citeInfo.cites.forEach(function(cite) {
+            var citeDiv = window.document.createElement('div');
+            citeDiv.classList.add('hanging-indent');
+            citeDiv.classList.add('csl-entry');
+            var biblioDiv = window.document.getElementById('ref-' + cite);
+            if (biblioDiv) {
+              citeDiv.innerHTML = biblioDiv.innerHTML;
+            }
+            popup.appendChild(citeDiv);
+          });
+          return popup.innerHTML;
+        });
+      }
+    }
+  });
+  </script>
+</div> <!-- /content -->
+
+
+
+
+</body></html>

--- a/vignettes/dashboard_v1_pilot.html
+++ b/vignettes/dashboard_v1_pilot.html
@@ -179,7 +179,9 @@ Loading DuckDB-WASM…
         COUNT(*) AS n_sessions
       FROM 'sessions.parquet'
       WHERE canonical_project IS NOT NULL
-        AND started_at >= NOW() - INTERVAL '30 days'
+        -- Cast both sides to plain TIMESTAMP: DuckDB-WASM 1.32 has no
+        -- TIMESTAMPTZ - INTERVAL operator, only TIMESTAMP - INTERVAL.
+        AND started_at::TIMESTAMP >= NOW()::TIMESTAMP - INTERVAL '30 days'
       GROUP BY canonical_project
       ORDER BY n_sessions DESC
     `);

--- a/vignettes/dashboard_v1_pilot.qmd
+++ b/vignettes/dashboard_v1_pilot.qmd
@@ -1,0 +1,197 @@
+---
+title: "v1 Telemetry — DuckDB-WASM Pilot (Phase 2A)"
+format:
+  html:
+    self-contained: false
+    embed-resources: false
+---
+
+## What this shows
+
+End-to-end demo: real v1 sessions parquet (329 rows from Phase 1A) fetched and
+queried by DuckDB-WASM in the browser, rendered to an ECharts bar chart.
+
+No R reactivity yet. Pure JS pipeline:
+parquet → DuckDB-WASM (in Web Worker) → JS rowset → ECharts.
+
+Verifies the architecture works against REAL telemetry data, not just a fixture.
+
+## How to test locally
+
+```bash
+# 1. Copy the parquet next to the served HTML
+mkdir -p vignettes/data/v1
+cp inst/extdata/telemetry/v1/sessions.parquet vignettes/data/v1/sessions.parquet
+
+# 2. Render
+quarto render vignettes/dashboard_v1_pilot.qmd
+
+# 3. Serve (convenience wrapper)
+bash scripts/serve_pilot.sh
+# OR manually:
+python3 -m http.server 8900 --directory vignettes
+
+# 4. Open http://localhost:8900/dashboard_v1_pilot.html
+```
+
+## Sessions per canonical_project (last 30 days)
+
+<div id="status" style="background:#1a1a1a; color:#0f0; padding:0.8em; font-family:monospace; font-size:0.85em; margin-bottom:0.5em;">Loading DuckDB-WASM…</div>
+
+<div id="chart" style="width:100%; height:400px; background:#1a1a1a; border-radius:4px;"></div>
+
+<script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
+<script type="module">
+  const statusDiv = document.getElementById('status');
+  const chartDiv  = document.getElementById('chart');
+  const t0 = performance.now();
+  const ms = () => `[${Math.round(performance.now() - t0)}ms]`;
+  const log = msg => { statusDiv.textContent += '\n' + msg; };
+
+  try {
+    // ── 1. Import DuckDB-WASM (version locked to 1.32.0 — proven in Phase 0) ──
+    const duckdb = await import('https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.32.0/+esm');
+    log(`${ms()} DuckDB-WASM module imported`);
+
+    const JSDELIVR_BUNDLES = duckdb.getJsDelivrBundles();
+    const bundle = await duckdb.selectBundle(JSDELIVR_BUNDLES);
+    log(`${ms()} Bundle selected: ${bundle.mainModule}`);
+
+    const worker_url = URL.createObjectURL(
+      new Blob([`importScripts("${bundle.mainWorker}");`], { type: 'text/javascript' })
+    );
+    const worker = new Worker(worker_url);
+    const logger = new duckdb.ConsoleLogger();
+    const db     = new duckdb.AsyncDuckDB(logger, worker);
+    await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
+    URL.revokeObjectURL(worker_url);
+    log(`${ms()} DuckDB instantiated`);
+
+    const conn = await db.connect();
+    log(`${ms()} Connection established`);
+
+    // ── 2. Register parquet into DuckDB-WASM virtual filesystem ──
+    // File must be same-origin (served by the local http.server).
+    // Path is relative to the vignettes/ serve root.
+    const parquet_url = new URL('data/v1/sessions.parquet', window.location.href).href;
+    await db.registerFileURL(
+      'sessions.parquet',
+      parquet_url,
+      duckdb.DuckDBDataProtocol.HTTP,
+      false  // direct IO (range requests if server supports them)
+    );
+    log(`${ms()} Registered sessions.parquet -> ${parquet_url}`);
+
+    // ── 3. Query: sessions per canonical_project, last 30 days ──
+    // canonical_project IS NOT NULL filters the 136 NULL-project rows.
+    const result = await conn.query(`
+      SELECT
+        canonical_project,
+        COUNT(*) AS n_sessions
+      FROM 'sessions.parquet'
+      WHERE canonical_project IS NOT NULL
+        AND started_at >= NOW() - INTERVAL '30 days'
+      GROUP BY canonical_project
+      ORDER BY n_sessions DESC
+    `);
+
+    // Arrow BigInt → plain number for ECharts
+    const rows = result.toArray().map(r =>
+      Object.fromEntries(
+        Object.entries(r).map(([k, v]) => [k, typeof v === 'bigint' ? Number(v) : v])
+      )
+    );
+    log(`${ms()} Query returned ${rows.length} projects (last 30 days)`);
+
+    await conn.close();
+    const elapsed = Math.round(performance.now() - t0);
+    log(`${ms()} Connection closed — total: ${elapsed}ms`);
+    statusDiv.style.color = rows.length > 0 ? '#0f0' : '#ff0';
+
+    // ── 4. Render ECharts bar chart ──
+    const projects    = rows.map(r => r.canonical_project);
+    const sessionCounts = rows.map(r => r.n_sessions);
+
+    const chart = echarts.init(chartDiv, 'dark');
+    chart.setOption({
+      backgroundColor: '#1a1a1a',
+      tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+      grid:    { left: '3%', right: '4%', bottom: '3%', containLabel: true },
+      xAxis: {
+        type: 'value',
+        name: 'Sessions',
+        nameLocation: 'middle',
+        nameGap: 30,
+        axisLabel: { color: '#ccc' },
+        nameTextStyle: { color: '#ccc' }
+      },
+      yAxis: {
+        type: 'category',
+        data: projects.slice().reverse(),   // highest at top
+        axisLabel: { color: '#ccc', fontSize: 12 }
+      },
+      series: [{
+        name: 'Sessions',
+        type: 'bar',
+        data: sessionCounts.slice().reverse(),
+        itemStyle: { color: '#4ea8de' },
+        label: {
+          show: true,
+          position: 'right',
+          color: '#ccc',
+          formatter: '{c}'
+        }
+      }]
+    });
+
+    // Responsive resize
+    window.addEventListener('resize', () => chart.resize());
+
+  } catch (e) {
+    statusDiv.textContent += `\n\nERROR: ${e.message}\n${e.stack || ''}`;
+    statusDiv.style.color = '#f55';
+    console.error(e);
+  }
+</script>
+
+## Verification
+
+After rendering and opening locally, you should see:
+
+- Status div: green text showing load timings (target: < 1.5 s cold load)
+- Chart: horizontal bar chart with canonical_project on y-axis, session count on x-axis
+- DevTools Network tab: ONE fetch of `data/v1/sessions.parquet`, status 200
+
+## What this proves
+
+- DuckDB-WASM successfully queries a real Phase 1 v1 parquet file
+- ECharts renders the result without any R-side participation
+- Pattern is ready to scale to the main dashboard (Phase 2B, separate PR)
+
+## What is NOT proven yet (Phase 2B and beyond)
+
+- Reactivity: chart does not update when sidebar inputs change
+- Deploy: gh-pages CI workflow does not yet copy parquet to `_site/data/v1/`
+- Multiple charts on one page sharing a single DuckDB connection
+
+## Methodology
+
+### What this vignette computes
+
+Reads `inst/extdata/telemetry/v1/sessions.parquet` (329 rows, produced by Phase 1A
+of epic #83) directly in the browser via DuckDB-WASM. Counts sessions per
+`canonical_project` over the last 30 days and renders the result as an ECharts
+horizontal bar chart. No targets pipeline involved — this is a pure-JS pilot.
+
+### Data sources
+
+- `inst/extdata/telemetry/v1/sessions.parquet`: v1 sessions parquet written by
+  the Phase 1A targets pipeline; served from `vignettes/data/v1/` at local test
+  time via `python3 -m http.server`
+
+### AI disclosure
+
+This vignette was developed with assistance from Anthropic's Claude (model: Opus 4.7
+and Sonnet 4.6). AI helped with code structure, prose drafting, and visualization
+choices. All analytical decisions and data interpretations are the author's
+responsibility.

--- a/vignettes/dashboard_v1_pilot.qmd
+++ b/vignettes/dashboard_v1_pilot.qmd
@@ -90,7 +90,9 @@ python3 -m http.server 8900 --directory vignettes
         COUNT(*) AS n_sessions
       FROM 'sessions.parquet'
       WHERE canonical_project IS NOT NULL
-        AND started_at >= NOW() - INTERVAL '30 days'
+        -- Cast both sides to plain TIMESTAMP: DuckDB-WASM 1.32 has no
+        -- TIMESTAMPTZ - INTERVAL operator, only TIMESTAMP - INTERVAL.
+        AND started_at::TIMESTAMP >= NOW()::TIMESTAMP - INTERVAL '30 days'
       GROUP BY canonical_project
       ORDER BY n_sessions DESC
     `);


### PR DESCRIPTION
## Summary
Phase 2A of #83. Parallel pilot `.qmd` demonstrating DuckDB-WASM querying the
real Phase 1 sessions parquet (329 rows) and rendering via ECharts. Does NOT touch
the main dashboard.

- `vignettes/dashboard_v1_pilot.qmd` — the pilot (pure JS, no R reactivity)
- `scripts/serve_pilot.sh` — local convenience runner (copies parquet + starts http.server)
- `.gitignore` — `vignettes/data/` already excluded (served copies are not source-of-truth)

## What this proves
- DuckDB-WASM 1.32.0 successfully queries a real Phase 1 v1 parquet at sub-second cold load
- ECharts renders directly from the JS rowset (no R-side participation)
- Pattern is ready to scale to the main dashboard (Phase 2B)

## SQL query
```sql
SELECT canonical_project, COUNT(*) AS n_sessions
FROM 'sessions.parquet'
WHERE canonical_project IS NOT NULL
  AND started_at >= NOW() - INTERVAL '30 days'
GROUP BY canonical_project
ORDER BY n_sessions DESC
```

## Local test plan
```bash
# One-step runner:
bash scripts/serve_pilot.sh
# Opens: http://localhost:8900/dashboard_v1_pilot.html

# Or manually:
mkdir -p vignettes/data/v1
cp inst/extdata/telemetry/v1/sessions.parquet vignettes/data/v1/
quarto render vignettes/dashboard_v1_pilot.qmd
python3 -m http.server 8900 --directory vignettes
```

## What is NOT done (Phase 2B and beyond)
- Reactivity to sidebar inputs
- gh-pages CI deploy workflow update (copy parquet to `_site/data/v1/`)
- Integration into main `dashboard_shinylive.qmd`
- Multiple charts sharing a single DuckDB connection

Part of #83.