### PR TITLE
fix(roborev): Group A+E dashboard/CI HIGH findings

### DIFF
--- a/.github/workflows/deploy-dashboard.yaml
+++ b/.github/workflows/deploy-dashboard.yaml
@@ -270,7 +270,8 @@ jobs:
             fi
           done
           if [ "$FAIL" = "1" ]; then
-            echo "::warning::Some deployment health checks failed — inspect logs"
+            echo "::error::Some deployment health checks failed — inspect logs"
+            exit 1
           else
             echo "All deployment checks passed"
           fi

--- a/vignettes/dashboard_shinylive.qmd
+++ b/vignettes/dashboard_shinylive.qmd
@@ -285,17 +285,17 @@ pal <- list(claude = "#377eb8", gemini = "#e41a1c", accent = "#4daf4a",
             purple = "#984ea3", orange = "#ff7f00", hist = "#377eb8")
 
 # --- Data loading -------------------------------------------------------------
-# Empty base_url means fetch from same origin as the served HTML — works for
-# both local walkthrough (python -m http.server) and production (gh-pages).
-# When the HTML is served locally, "/data/X.json" resolves to localhost.
-# When the HTML is served from gh-pages, "/data/X.json" resolves to
-# https://johngavin.github.io/llmtelemetry/data/X.json (same as before).
-base_url <- ""
+# base_url is a relative prefix so fetches work from any host+path.
+# "/data/X.json" would be an absolute path — on the GH Pages project site at
+# https://johngavin.github.io/llmtelemetry/ it resolves to the wrong host
+# root. Using "data/" as a relative prefix resolves correctly from wherever
+# the HTML is served (local http.server or gh-pages sub-path).
+base_url <- "data/"
 
 load_json <- function(filename) {
   tryCatch({
     tmp <- tempfile(fileext = ".json")
-    download.file(paste0(base_url, "/data/", filename), tmp, mode = "w", quiet = TRUE)
+    download.file(paste0(base_url, filename), tmp, mode = "w", quiet = TRUE)
     fromJSON(txt = tmp, simplifyDataFrame = TRUE)
   }, error = function(e) {
     message("Failed to load ", filename, ": ", e$message)
@@ -885,7 +885,7 @@ ui <- page_navbar(
     layout_columns(col_widths = c(6, 6),
       card(min_height = "400px", card_header("Bus Factor (All Time)"), uiOutput("rh_bus_all"),
         card_footer(class = "text-muted small", "Contributor commit share — 1 person at 60%+ = risk")),
-      card(min_height = "400px", card_header("Bus Factor (1 Month)"), uiOutput("rh_bus_6mo"),
+      card(min_height = "400px", card_header("Bus Factor (6 Months)"), uiOutput("rh_bus_6mo"),
         card_footer(class = "text-muted small", "Recent contributor concentration"))
     ),
     layout_columns(col_widths = c(6, 6),
@@ -895,8 +895,8 @@ ui <- page_navbar(
         card_footer(class = "text-muted small", "When commits happen — hour vs day of week"))
     ),
     layout_columns(col_widths = c(12),
-      card(min_height = "400px", card_header("File Growth (1-Week Rolling)"), uiOutput("rh_file_growth"),
-        card_footer(class = "text-muted small", "1-week rolling aggregate of files added vs deleted — green = additions, red = deletions"))
+      card(min_height = "400px", card_header("File Growth (6-Month Rolling)"), uiOutput("rh_file_growth"),
+        card_footer(class = "text-muted small", "6-month rolling aggregate of files added vs deleted — green = additions, red = deletions"))
     ),
     layout_columns(col_widths = c(6, 6),
       card(min_height = "400px", card_header("Churn Hotspots"), uiOutput("rh_churn"),
@@ -1047,10 +1047,17 @@ server <- function(input, output, session) {
   })
   observeEvent(input$sel_invert, {
     current <- input$selected_projects
-    # sentinel values are not real projects — exclude them when inverting
-    real_current <- setdiff(current, c("__ALL__", "__NONE__"))
-    inverted <- setdiff(all_projects, real_current)
-    # Collapse to sentinel when the inverted set is "everything" or "nothing"
+    # Handle sentinel states first — invert of ALL is NONE and vice versa
+    if (identical(current, "__ALL__")) {
+      updateSelectInput(session, "selected_projects", selected = "__NONE__")
+      return()
+    }
+    if (identical(current, "__NONE__")) {
+      updateSelectInput(session, "selected_projects", selected = "__ALL__")
+      return()
+    }
+    # Real project list: invert selection relative to all_projects
+    inverted <- setdiff(all_projects, current)
     new_sel <- if (length(inverted) == 0) "__NONE__"
                else if (length(inverted) == length(all_projects)) "__ALL__"
                else inverted
@@ -1058,9 +1065,10 @@ server <- function(input, output, session) {
   })
 
   # Helper: resolve selected_projects input -> character vector of project names
-  # Returns NULL (meaning "all projects") when __ALL__ is selected.
+  # Returns all_projects (canonical list) when __ALL__ is selected so that
+  # orphan/worktree rows (NA project) are always excluded by the %in% filter.
   resolve_sel <- function(sel) {
-    if (is.null(sel) || "__ALL__" %in% sel) return(NULL)
+    if (is.null(sel) || "__ALL__" %in% sel) return(all_projects)
     if ("__NONE__" %in% sel) return(character(0))
     sel
   }
@@ -2038,7 +2046,7 @@ server <- function(input, output, session) {
     ), aria_label = label)
   }
   output$rh_bus_all <- renderUI(bus_dot(git_bus$all_time, "Bus factor all time: contributor commit share"))
-  output$rh_bus_6mo <- renderUI(bus_dot(git_bus$recent_6mo, "Bus factor 1 month: recent contributor concentration"))
+  output$rh_bus_6mo <- renderUI(bus_dot(git_bus$recent_6mo, "Bus factor 6 months: recent contributor concentration"))
 
   output$rh_velocity <- renderUI({
     if (!has_rows(git_vel)) return(ec_empty())


### PR DESCRIPTION
## Summary

Fixes 6 HIGH-severity roborev findings in the dashboard and CI workflow.

- **#895**: CI health check step set `FAIL=1` but never ran `exit 1`, so the step always exited 0 even when error patterns were found in deployed HTML. Changed `::warning::` to `::error::` and added `exit 1`.
- **#925**: `base_url <- ""` combined with `paste0(base_url, "/data/", filename)` produced an absolute path (`/data/X.json`) that resolves to the wrong host root on the GH Pages project site. Changed to `base_url <- "data/"` with `paste0(base_url, filename)` for truly relative fetch URLs.
- **#927**: The "File Growth" card header and footer said "1-Week Rolling" but the underlying data (`rh_file_growth`) is computed as 6-month rolling aggregates. Corrected to "6-Month Rolling".
- **#952**: The "Bus Factor (1 Month)" card header reads from `git_bus$recent_6mo`. Corrected to "Bus Factor (6 Months)" and updated the aria_label accordingly.
- **#1031**: The Invert button's `observeEvent` stripped `__ALL__` from `current` via `setdiff()` before computing `inverted`, so `__ALL__` always produced `character(0)` → collapsed back to `__ALL__` (no-op). Added sentinel-first handling: invert of `__ALL__` → `__NONE__` and vice versa, before the real-project setdiff.
- **#906**: `resolve_sel()` returned `NULL` when `__ALL__` was selected, meaning callers' `if (!is.null(sel))` guards skipped the project filter entirely, allowing orphan/worktree rows (NA canonical_project) to appear. Changed `resolve_sel` to return `all_projects` (the canonical list) instead of `NULL`, so the `%in%` filter always runs and NA rows are excluded.

## Test plan

- [ ] Verify CI workflow fails (exits 1) when error patterns appear in deployed HTML
- [ ] Verify dashboard data fetches work on GH Pages (`/llmtelemetry/` sub-path)
- [ ] Verify File Growth card shows "6-Month Rolling" header and footer
- [ ] Verify Bus Factor recent card shows "6 Months"
- [ ] Verify Invert button toggles ALL→NONE and NONE→ALL correctly
- [ ] Verify no orphan/worktree rows appear when "All projects" is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)