### PR TITLE
fix(roborev): Group 2 HIGH findings — #872 #877 #1032

### DIFF
--- a/inst/scripts/export_dashboard_data.R
+++ b/inst/scripts/export_dashboard_data.R
@@ -234,6 +234,9 @@ if (has_cmonitor) {
   cat(sprintf("  -> %d active blocks\n", nrow(blk_rows)))
 
   # --- 3b. Per-model daily breakdown from model_stats -------------------------
+  # NOTE (#1032): model_daily is a GLOBAL metric (cost/tokens by model, not by
+  # project). It must NEVER be filtered by canonical_project or any project
+  # membership condition — doing so would silently corrupt historical dates.
   cat("Exporting per-model daily data...\n")
   model_daily <- lapply(blocks_all, function(b) {
     if (isTRUE(b$is_gap) || is.null(b$model_stats)) return(NULL)
@@ -411,7 +414,7 @@ tracked_repos <- list(
 )
 
 parse_git_log <- function(repo_path, project_name) {
-  if (!dir.exists(file.path(repo_path, ".git"))) return(NULL)
+  if (!file.exists(file.path(repo_path, ".git"))) return(NULL)
   raw <- tryCatch(
     system(
       sprintf("git -C '%s' log '--format=%%H|%%ai|%%s' --numstat --since='1 year ago'",
@@ -590,8 +593,8 @@ cat("Exporting file churn per project...\n")
 # For each tracked repo: git log --numstat --since='1 year ago', aggregate per file.
 
 parse_git_numstat_files <- function(repo_path, project_name, since = "1 year ago") {
-  if (!dir.exists(file.path(repo_path, ".git"))) {
-    warning(sprintf("Skipping %s: .git dir not found at %s", project_name, repo_path))
+  if (!file.exists(file.path(repo_path, ".git"))) {
+    warning(sprintf("Skipping %s: .git not found at %s", project_name, repo_path))
     return(NULL)
   }
   raw <- tryCatch(
@@ -690,8 +693,8 @@ cat("Exporting change coupling...\n")
 # Keep top 100 pairs per project with n_cochanges >= 3.
 
 parse_git_coupling <- function(repo_path, project_name, since = "1 year ago") {
-  if (!dir.exists(file.path(repo_path, ".git"))) {
-    warning(sprintf("Skipping %s: .git dir not found at %s", project_name, repo_path))
+  if (!file.exists(file.path(repo_path, ".git"))) {
+    warning(sprintf("Skipping %s: .git not found at %s", project_name, repo_path))
     return(NULL)
   }
   raw <- tryCatch(

--- a/scripts/backup_extdata.sh
+++ b/scripts/backup_extdata.sh
@@ -18,9 +18,14 @@ if [ ! -d "$BACKUP_DIR/.git" ]; then
     mkdir -p "$BACKUP_DIR"
     git -C "$BACKUP_DIR" init -b main
     git -C "$BACKUP_DIR" remote add origin "$DATA_REMOTE"
-    # Try to pull existing history; ignore error if repo is empty
-    git -C "$BACKUP_DIR" fetch origin main 2>/dev/null && \
-        git -C "$BACKUP_DIR" checkout main || true
+    # Fetch existing history from remote (may be empty on first ever use)
+    git -C "$BACKUP_DIR" fetch origin 2>/dev/null || true
+    # If origin/main already exists, reset local branch to it before adding
+    # new content — avoids an unrelated root commit that would be rejected as
+    # a non-fast-forward push (#877).
+    if git -C "$BACKUP_DIR" rev-parse --verify origin/main >/dev/null 2>&1; then
+        git -C "$BACKUP_DIR" checkout -B main origin/main
+    fi
 fi
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **#872 (git worktree detection)**: Changed `dir.exists(file.path(repo, ".git"))` to `file.exists()` in all three parser functions (`parse_git_log`, `parse_git_numstat_files`, `parse_git_coupling`). In a git worktree `.git` is a file not a directory, so `dir.exists()` returned FALSE and silently skipped the repo. `file.exists()` works for both normal clones and worktrees.

- **#877 (backup first-run root commit)**: Fixed `scripts/backup_extdata.sh` to check whether `origin/main` exists after fetching and, if so, reset the local branch to it with `git checkout -B main origin/main` before adding new content. Previously the script would create a new unrelated root commit on first run when the remote already had history, causing `git push` to be rejected as non-fast-forward.

- **#1032 (model_daily canonicalization)**: Investigated and confirmed `model_daily.json` is already independent of project canonicalization — it is derived solely from raw cmonitor-rs `blocks_all` data with no project filtering. The 123 pre-Apr4 rows are intact and correct (earliest: 2026-02-15). Added a protective `NOTE (#1032)` comment to guard against future regressions.

## Test plan

- [ ] Run `export_dashboard_data.R` from a git worktree path — all three parse functions should now process repos correctly
- [ ] Run `backup_extdata.sh` for the first time against a remote with existing history — confirm it resets to `origin/main` and pushes as fast-forward
- [ ] Verify `model_daily.json` row count ≥ 249 (pre-Apr4 rows preserved)
- [ ] `pkgload::load_all()` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)