### PR TITLE
fix(roborev): Group 1 dashboard HIGH findings #746 #888 #1711 #1718

### DIFF
--- a/vignettes/dashboard_shinylive.qmd
+++ b/vignettes/dashboard_shinylive.qmd
@@ -1012,13 +1012,13 @@ server <- function(input, output, session) {
     if (!has_rows(gem_daily)) return(data.frame())
     gem_daily[gem_daily$date >= cutoff(), ]
   })
+  # cc_daily is a global aggregate (project == "all" for every row).
+  # It has no per-project breakdown, so the shared project selector cannot
+  # meaningfully filter it — doing so silently empties Cost Trends and
+  # Token Analysis whenever anything other than "All projects" is selected.
+  # (#746) Use the time-filtered data directly without applying the project filter.
   cc_d_proj <- reactive({
-    d <- cc_d()
-    if (nrow(d) == 0) return(d)
-    sel <- resolve_sel(input$selected_projects)
-    if (!is.null(sel) && "project" %in% names(d))
-      d <- d[d$project %in% sel, ]
-    d
+    cc_d()
   })
 
   # --- Phase B: one-shot sidebar population from projects_master.json ----------
@@ -1769,21 +1769,26 @@ server <- function(input, output, session) {
       proj_lookup[f] <- c(rows_a, rows_b)[1]
     }
     cat_map <- c("llm" = 0L, "llmtelemetry" = 1L)
+    # (#888) Use full repo-relative path as node id to avoid collisions when
+    # two files share the same basename (e.g. R/utils.R and tests/utils.R).
+    # basename() is kept only as the human-readable display label.
+    # ECharts graph series matches edge source/target to node id when id is
+    # provided, so edges also use full paths as identifiers.
     nodes <- lapply(all_files, function(f) {
       cat_idx <- if (!is.na(proj_lookup[f]) && proj_lookup[f] %in% names(cat_map)) {
         cat_map[[proj_lookup[f]]]
       } else {
         2L
       }
-      list(name = basename(f), value = 1,
+      list(id = f, name = basename(f), value = 1,
            symbolSize = 10,
            category = cat_idx)
     })
 
     edges <- lapply(seq_len(nrow(d)), function(i) {
       w <- d$weight_normalised[i]
-      list(source = basename(d$file_a[i]),
-           target = basename(d$file_b[i]),
+      list(source = d$file_a[i],
+           target = d$file_b[i],
            n_cochanges = d$n_cochanges[i],
            lineStyle = list(width = max(1, round(w * 5)),
                             opacity = max(0.3, w)))

--- a/vignettes/dashboard_v1_pilot.qmd
+++ b/vignettes/dashboard_v1_pilot.qmd
@@ -90,9 +90,14 @@ python3 -m http.server 8900 --directory vignettes
         COUNT(*) AS n_sessions
       FROM 'sessions.parquet'
       WHERE canonical_project IS NOT NULL
+        -- (#1711/#1718) Anchor to the most recent record in the snapshot
+        -- instead of NOW() so the window does not decay to zero as wall-clock
+        -- time advances past the snapshot date.
         -- Cast both sides to plain TIMESTAMP: DuckDB-WASM 1.32 has no
         -- TIMESTAMPTZ - INTERVAL operator, only TIMESTAMP - INTERVAL.
-        AND started_at::TIMESTAMP >= NOW()::TIMESTAMP - INTERVAL '30 days'
+        AND started_at::TIMESTAMP >= (
+              SELECT MAX(started_at)::TIMESTAMP FROM 'sessions.parquet'
+            ) - INTERVAL '30 days'
       GROUP BY canonical_project
       ORDER BY n_sessions DESC
     `);


### PR DESCRIPTION
## Summary

- **#746** `cc_d_proj()` reactive no longer applies the shared project selector to `cc_daily`. The ccusage daily data is a global aggregate (`project == "all"` for every row) with no per-project breakdown, so filtering by real project names (llm, llmtelemetry, etc.) silently emptied both Cost Trends and Token Analysis tabs. Fix: `cc_d_proj()` now simply returns `cc_d()` (time-filtered only).
- **#888** Change-coupling force graph nodes now carry `id = <full-repo-path>` as the unique ECharts node identifier, with `name = basename(path)` for display only. Previously both nodes and edge endpoints used `basename()`, causing files with the same filename in different directories to collapse to a single node and rewire edges incorrectly.
- **#1711 / #1718** Pilot dashboard 30-day window now anchored to `MAX(started_at)` from the snapshot instead of `NOW()`. With `NOW()` the bar chart decayed to zero rows as wall-clock time advanced past the static parquet snapshot window.

## Files changed

- `vignettes/dashboard_shinylive.qmd` — fixes #746 and #888
- `vignettes/dashboard_v1_pilot.qmd` — fixes #1711 and #1718

## Test plan

- [ ] Cost Trends tab renders data when a specific project is selected in the sidebar
- [ ] Token Analysis tab renders data when a specific project is selected in the sidebar
- [ ] Change-coupling graph displays distinct nodes for files sharing the same basename (e.g. `R/utils.R` vs `tests/utils.R`)
- [ ] Pilot dashboard bar chart shows non-zero rows regardless of current date

🤖 Generated with [Claude Code](https://claude.com/claude-code)