### PR TITLE
fix(roborev): R package API quality #1670 #814 #1652 #1657

### DIFF
--- a/R/read_unified.R
+++ b/R/read_unified.R
@@ -60,7 +60,9 @@ unified_summary <- function(db_path = file.path(Sys.getenv("HOME"), ".claude", "
 
   tables <- DBI::dbListTables(con)
   purrr::map_dfr(tables, function(tbl_name) {
-    n <- nrow(DBI::dbReadTable(con, tbl_name))
+    n <- DBI::dbGetQuery(
+      con, sprintf("SELECT count(*) FROM %s", tbl_name)
+    )[[1]]
     tibble::tibble(table = tbl_name, rows = as.integer(n))
   })
 }

--- a/R/rollup_sessions.R
+++ b/R/rollup_sessions.R
@@ -7,19 +7,32 @@
 #'
 #' `arrow` is not required; DuckDB's built-in Parquet writer is used instead.
 #'
-#' @param input_path Path to `unified_sessions.json`. Defaults to the package's
-#'   `inst/extdata/unified_sessions.json`.
-#' @param output_path Where to write `sessions.parquet`. Defaults to
-#'   `inst/extdata/telemetry/v1/sessions.parquet`.
+#' @param input_path Path to `unified_sessions.json`. Defaults to `NULL`,
+#'   resolved via `system.file()` for an installed package or `here::here()`
+#'   during development.
+#' @param output_path Where to write `sessions.parquet`. Defaults to `NULL`,
+#'   resolved to `inst/extdata/telemetry/v1/sessions.parquet` relative to the
+#'   project root via `here::here()`.
 #' @param now Override the `valid_from` timestamp. Mainly useful in tests to
 #'   produce deterministic output. Defaults to `Sys.time()`.
 #' @return Invisibly returns a data frame with the transformed rows (v1 schema).
 #' @export
 rollup_sessions <- function(
-  input_path  = here::here("inst", "extdata", "unified_sessions.json"),
-  output_path = here::here("inst", "extdata", "telemetry", "v1", "sessions.parquet"),
+  input_path  = NULL,
+  output_path = NULL,
   now = Sys.time()
 ) {
+  if (is.null(input_path)) {
+    input_path <- system.file("extdata", "unified_sessions.json",
+                              package = "llmtelemetry")
+    if (!nzchar(input_path)) {
+      input_path <- here::here("inst", "extdata", "unified_sessions.json")
+    }
+  }
+  if (is.null(output_path)) {
+    output_path <- here::here("inst", "extdata", "telemetry", "v1",
+                              "sessions.parquet")
+  }
   dir.create(dirname(output_path), recursive = TRUE, showWarnings = FALSE)
 
   # --- 1. Read input --------------------------------------------------------

--- a/R/schema.R
+++ b/R/schema.R
@@ -20,6 +20,9 @@ apply_schema_v1 <- function(con) {
     ddl_dir <- here::here("inst", "schema", "v1")
   }
   sql_files <- list.files(ddl_dir, pattern = "\\.sql$", full.names = TRUE)
+  if (length(sql_files) == 0L) {
+    cli::cli_abort("Schema directory not found; no SQL files resolved")
+  }
   for (f in sql_files) {
     DBI::dbExecute(con, paste(readLines(f, warn = FALSE), collapse = "\n"))
   }

--- a/man/rollup_sessions.Rd
+++ b/man/rollup_sessions.Rd
@@ -4,18 +4,16 @@
 \alias{rollup_sessions}
 \title{Backfill the v1 sessions parquet from unified_sessions.json}
 \usage{
-rollup_sessions(
-  input_path = here::here("inst", "extdata", "unified_sessions.json"),
-  output_path = here::here("inst", "extdata", "telemetry", "v1", "sessions.parquet"),
-  now = Sys.time()
-)
+rollup_sessions(input_path = NULL, output_path = NULL, now = Sys.time())
 }
 \arguments{
-\item{input_path}{Path to \code{unified_sessions.json}. Defaults to the package's
-\code{inst/extdata/unified_sessions.json}.}
+\item{input_path}{Path to \code{unified_sessions.json}. Defaults to \code{NULL},
+resolved via \code{system.file()} for an installed package or \code{here::here()}
+during development.}
 
-\item{output_path}{Where to write \code{sessions.parquet}. Defaults to
-\code{inst/extdata/telemetry/v1/sessions.parquet}.}
+\item{output_path}{Where to write \code{sessions.parquet}. Defaults to \code{NULL},
+resolved to \code{inst/extdata/telemetry/v1/sessions.parquet} relative to the
+project root via \code{here::here()}.}
 
 \item{now}{Override the \code{valid_from} timestamp. Mainly useful in tests to
 produce deterministic output. Defaults to \code{Sys.time()}.}


### PR DESCRIPTION
## Summary

- **#1670**: `devtools::document()` confirms `rollup_git_commits` is in NAMESPACE and `man/rollup_git_commits.Rd` exists; regenerated `rollup_sessions.Rd` with updated param docs
- **#814**: `unified_summary()` replaced `DBI::dbReadTable()` + `nrow()` with a `SELECT count(*) FROM <tbl>` SQL query — avoids materialising entire tables just to count rows
- **#1652**: `apply_schema_v1()` now calls `cli::cli_abort()` when `length(sql_files) == 0`, preventing silent no-ops when the schema directory is missing
- **#1657**: `rollup_sessions()` default args changed from `here::here(...)` to `NULL`; the function body resolves `input_path` via `system.file()` (installed package) with `here::here()` dev fallback, and `output_path` via `here::here()`

## Test plan

- [x] `devtools::document()` ran cleanly — only `rollup_sessions.Rd` updated (param docs change)
- [x] `NAMESPACE` contains `export(rollup_git_commits)`
- [x] `man/rollup_git_commits.Rd` exists
- [x] `devtools::test()`: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 543 ]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)