### PR TITLE
fix(roborev): polling + CI + backup #789 #793 #2087 #2095

### DIFF
--- a/inst/scripts/poll_github_events.R
+++ b/inst/scripts/poll_github_events.R
@@ -17,6 +17,20 @@ projects <- c(
   "JohnGavin/footbet"
 )
 
+load_previous <- function(owner_repo) {
+  pkg_root <- here::here()
+  out_path <- file.path(pkg_root, "inst", "extdata", "github_issue_events.json")
+  if (!file.exists(out_path)) return(NULL)
+  tryCatch({
+    all_rows <- fromJSON(out_path, simplifyDataFrame = TRUE)
+    if (is.null(all_rows) || nrow(all_rows) == 0) return(NULL)
+    # Filter to only rows for this repo — avoids duplicating other projects' history
+    repo_rows <- all_rows[all_rows$project == owner_repo, ]
+    if (nrow(repo_rows) == 0) return(NULL)
+    repo_rows
+  }, error = function(e) NULL)
+}
+
 poll_issue_events <- function(owner_repo, since_days = 30) {
   cat(sprintf("Polling %s...\n", owner_repo))
 
@@ -25,26 +39,43 @@ poll_issue_events <- function(owner_repo, since_days = 30) {
   owner <- parts[1]
   repo <- parts[2]
 
-  # Fetch issue events via gh api (no pagination to avoid JSON concat issues)
+  # Fetch issue events via gh api with multi-page iteration (#789)
   result <- tryCatch({
-    events_json <- system2(
-      "gh",
-      args = c(
-        "api",
-        sprintf("/repos/%s/%s/issues/events?per_page=100", owner, repo)
-      ),
-      stdout = TRUE,
-      stderr = FALSE
-    )
+    page <- 1
+    all_events_raw <- list()
+    repeat {
+      url <- sprintf("repos/%s/%s/issues/events?per_page=100&page=%d", owner, repo, page)
+      page_json <- system2(
+        "gh",
+        args = c("api", url),
+        stdout = TRUE,
+        stderr = FALSE
+      )
+      status <- attr(page_json, "status")
+      if (!is.null(status) && status != 0) break
+      if (length(page_json) == 0 || identical(page_json[1], "")) break
+      parsed <- tryCatch(
+        fromJSON(paste(page_json, collapse = ""), simplifyDataFrame = FALSE),
+        error = function(e) NULL
+      )
+      if (is.null(parsed) || length(parsed) == 0) break
+      all_events_raw <- c(all_events_raw, parsed)
+      if (length(parsed) < 100) break
+      page <- page + 1
+    }
 
-    if (length(events_json) == 0 || events_json[1] == "") {
+    if (length(all_events_raw) == 0) {
       message(sprintf("  No events found for %s", owner_repo))
       return(NULL)
     }
 
-    events <- fromJSON(paste(events_json, collapse = ""), simplifyDataFrame = TRUE)
+    # Convert list-of-lists to data frame
+    events <- fromJSON(
+      jsonlite::toJSON(all_events_raw, auto_unbox = TRUE),
+      simplifyDataFrame = TRUE
+    )
 
-    if (nrow(events) == 0) {
+    if (is.null(events) || nrow(events) == 0) {
       message(sprintf("  Empty events for %s", owner_repo))
       return(NULL)
     }
@@ -65,11 +96,11 @@ poll_issue_events <- function(owner_repo, since_days = 30) {
     events_clean$created_at <- as.POSIXct(events_clean$created_at, format = "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
     events_clean <- events_clean[events_clean$created_at >= cutoff, ]
 
-    cat(sprintf("  Found %d events (last %d days)\n", nrow(events_clean), since_days))
+    cat(sprintf("  Found %d events across %d page(s) (last %d days)\n", nrow(events_clean), page, since_days))
     events_clean
   }, error = function(e) {
-    message(sprintf("  Error fetching %s: %s", owner_repo, e$message))
-    NULL
+    message(sprintf("  Error fetching %s: %s — using previous data for this repo", owner_repo, e$message))
+    load_previous(owner_repo)
   })
 
   result

--- a/scripts/backup_extdata.sh
+++ b/scripts/backup_extdata.sh
@@ -18,9 +18,9 @@ if [ ! -d "$BACKUP_DIR/.git" ]; then
     mkdir -p "$BACKUP_DIR"
     git -C "$BACKUP_DIR" init -b main
     git -C "$BACKUP_DIR" remote add origin "$DATA_REMOTE"
-    # Try to pull existing history; ignore error if repo is empty
-    git -C "$BACKUP_DIR" fetch origin main 2>/dev/null && \
-        git -C "$BACKUP_DIR" checkout main || true
+    # Try to pull existing history; ignore error only if the remote repo is truly empty
+    git -C "$BACKUP_DIR" fetch origin || { echo "ERROR: git fetch origin failed — aborting backup"; exit 1; }
+    git -C "$BACKUP_DIR" checkout main 2>/dev/null || true
 fi
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **#789** `poll_github_events.R`: replaced single `?per_page=100` call with a `repeat` loop that increments `page=` until the API returns fewer than 100 results, collecting all pages before converting to a data frame.
- **#793** `qa_dashboard_content.sh`: `TODAY` is already initialized unconditionally at the top of the script (line 12); confirmed no regression — the variable is defined before any conditional branch that references it.
- **#2087** `poll_github_events.R`: added `load_previous()` helper that reads the existing `github_issue_events.json` and filters to rows where `project == owner_repo` only. The per-repo error path now calls `load_previous(owner_repo)` instead of returning `NULL`, preventing unrelated repos' history from being duplicated.
- **#2095** `scripts/backup_extdata.sh`: removed `|| true` from `git fetch origin`. Fetch failure now aborts with an explicit error message via `|| { echo "ERROR: ..."; exit 1; }`. The downstream `git checkout main || true` retains its `|| true` because it legitimately fails on an empty remote repo.

## Test plan

- [ ] Bash syntax checks pass: `bash -n inst/scripts/qa_dashboard_content.sh` and `bash -n scripts/backup_extdata.sh`
- [ ] R parse check passes: `Rscript --no-init-file -e 'parse("inst/scripts/poll_github_events.R")'`
- [ ] Manually run `poll_github_events.R` against a repo with >100 events and confirm multiple pages are fetched
- [ ] Simulate `gh api` failure for one repo and confirm `load_previous()` returns only that repo's rows
- [ ] Simulate a network failure during backup and confirm the script exits non-zero with the error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)