### PR TITLE
fix(roborev): block_table sort order — remove lexicographic re-sort #896

### DIFF
--- a/vignettes/dashboard_shinylive.qmd
+++ b/vignettes/dashboard_shinylive.qmd
@@ -1848,7 +1848,7 @@ server <- function(input, output, session) {
             "function(data, type, row) { return '<span style=\"white-space:nowrap\">' + data + '</span>'; }"
           ))
         ),
-        order = list(list(0, "desc"))
+        order = list()  # preserve server-side sort (d$startTime decreasing) — #896
       ),
       rownames = FALSE)
   })


### PR DESCRIPTION
## Summary

- **#896** `block_table` DataTable was re-sorting by the `Day` string (`"Wed 2026-05-13"`) with `order = list(list(0, "desc"))`. This sorts lexicographically by weekday name, so "Sat" rows appear before "Wed" rows even when the Saturday date is later. The data frame is already pre-sorted by `d$startTime` descending on the server side — `order = list()` preserves that order without client-side re-sort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)