### PR TITLE
fix(codex-epic): roborev round V — a/c/d (non-breaking) [alt to #134]

### DIFF
--- a/R/canonicalize.R
+++ b/R/canonicalize.R
@@ -20,7 +20,28 @@
   x <- gsub("^docs[-_]gh[-_]",               "", x)
   x <- gsub("^llm-",                          "", x)
   x <- gsub("^proj-",                         "", x)
+  # Convert dash separators to slash (dash-form hook output -> slash-form).
   x <- gsub("-", "/", x, fixed = TRUE)
+
+  # Handle underscore-form nested paths emitted by some sanitiser variants
+  # (e.g. "docs_gh_llmtelemetry", "-Users_johngavin_docs_gh_llm").
+  # IMPORTANT: apply BEFORE dash-to-slash conversion has altered leading "-",
+  # so we detect path-like prefixes on the ORIGINAL input.  Bare single-token
+  # underscore names that appear in meta_only (e.g. "urban_planning") must NOT
+  # be touched — the FIRST PATH SEGMENT check in the caller guards them later.
+  # Detection: the raw value starts with "-" or "docs_gh_" (before any
+  # conversion), which means we must re-test the pre-converted original here.
+  # Since dash-to-slash already ran, we check the post-slash form for the
+  # equivalent patterns: a leading "/" (was "-"), or literal "docs_gh_".
+  is_path_like <- startsWith(x, "/") || startsWith(x, "docs_gh_")
+  if (is_path_like) {
+    x <- gsub("^/Users_johngavin_docs_gh_", "", x)
+    x <- gsub("^/docs_gh_",                 "", x)
+    x <- gsub("^docs_gh_",                  "", x)
+    x <- gsub("^llm_",                       "", x)
+    x <- gsub("^proj_",                      "", x)
+    x <- gsub("_", "/", x, fixed = TRUE)
+  }
   x
 }
 

--- a/inst/scripts/refresh_codex_cache.R
+++ b/inst/scripts/refresh_codex_cache.R
@@ -532,7 +532,7 @@ aggregate_daily <- function(turns) {
 write_json_atomic <- function(data, path, min_rows = 0L, label = basename(path)) {
   n_rows <- nrow(data)
   if (n_rows < min_rows &&
-      !isTRUE(as.logical(Sys.getenv("ALLOW_SHRINK", "false")))) {
+      !nzchar(Sys.getenv("ALLOW_SHRINK", ""))) {
     cli::cli_abort(c(
       "x" = "Refusing to write {label}: row count would shrink.",
       "i" = "Existing rows: {min_rows}; new combined rows: {n_rows}.",

--- a/inst/scripts/refresh_codex_cache.R
+++ b/inst/scripts/refresh_codex_cache.R
@@ -600,6 +600,26 @@ if (!interactive()) {
       left_join(repo_info, by = "thread_id")
   }
 
+  # ── Helper: atomic JSON write via temp-file rename ─────────────────────────
+  # Writes to a sibling .tmp file then renames atomically so that a SIGKILL /
+  # disk-full mid-write cannot truncate the production file.  Also asserts that
+  # the combined row count is monotone (>= existing) before writing so that an
+  # accidental upstream parse failure cannot silently truncate history.
+  write_json_atomic <- function(data, path, min_rows = 0L, label = basename(path)) {
+    n_rows <- nrow(data)
+    if (n_rows < min_rows) {
+      cli::cli_abort(c(
+        "x" = "Refusing to write {label}: row count would shrink.",
+        "i" = "Existing rows: {min_rows}; new combined rows: {n_rows}.",
+        "i" = "This indicates an upstream parse failure — aborting to protect history."
+      ))
+    }
+    tmp_path <- paste0(path, ".tmp")
+    jsonlite::write_json(data, tmp_path, auto_unbox = TRUE, digits = 6)
+    file.rename(tmp_path, path)
+    invisible(n_rows)
+  }
+
   # Read existing sessions and merge (incremental update)
   sessions_path <- file.path(extdata, "codex_sessions.json")
   existing_sessions <- if (file.exists(sessions_path)) {
@@ -607,6 +627,7 @@ if (!interactive()) {
              error = function(e) tibble())
   } else tibble()
 
+  n_existing_sessions <- if (is.data.frame(existing_sessions)) nrow(existing_sessions) else 0L
   if (is.data.frame(existing_sessions) && nrow(existing_sessions) > 0L) {
     existing_sessions <- as_tibble(existing_sessions)
     # Combine; new rows overwrite existing for same thread_id
@@ -618,7 +639,8 @@ if (!interactive()) {
     all_sessions <- sessions
   }
 
-  jsonlite::write_json(all_sessions, sessions_path, auto_unbox = TRUE, digits = 6)
+  write_json_atomic(all_sessions, sessions_path,
+                    min_rows = n_existing_sessions, label = "codex_sessions.json")
   cat(sprintf("Sessions  : %d total (%d new/updated)\n",
               nrow(all_sessions), nrow(sessions)))
 
@@ -632,6 +654,7 @@ if (!interactive()) {
              error = function(e) tibble())
   } else tibble()
 
+  n_existing_daily <- if (is.data.frame(existing_daily)) nrow(existing_daily) else 0L
   if (is.data.frame(existing_daily) && nrow(existing_daily) > 0L) {
     existing_daily <- as_tibble(existing_daily)
     # Remove rows that will be replaced by new data for same keys
@@ -647,7 +670,8 @@ if (!interactive()) {
     all_daily <- daily
   }
 
-  jsonlite::write_json(all_daily, daily_path, auto_unbox = TRUE, digits = 6)
+  write_json_atomic(all_daily, daily_path,
+                    min_rows = n_existing_daily, label = "codex_daily.json")
   cat(sprintf("Daily rows: %d total (%d new/updated)\n",
               nrow(all_daily), nrow(daily)))
 

--- a/inst/scripts/refresh_codex_cache.R
+++ b/inst/scripts/refresh_codex_cache.R
@@ -617,7 +617,9 @@ if (!interactive()) {
     tmp_path <- paste0(path, ".", Sys.getpid(), ".tmp")
     on.exit(if (file.exists(tmp_path)) unlink(tmp_path, force = TRUE), add = TRUE)
     jsonlite::write_json(data, tmp_path, auto_unbox = TRUE, digits = 6)
-    file.rename(tmp_path, path)
+    if (!file.rename(tmp_path, path)) {
+      cli::cli_abort("Atomic rename failed: {tmp_path} -> {path}")
+    }
     invisible(n_rows)
   }
 

--- a/inst/scripts/refresh_codex_cache.R
+++ b/inst/scripts/refresh_codex_cache.R
@@ -614,7 +614,7 @@ if (!interactive()) {
         "i" = "This indicates an upstream parse failure — aborting to protect history."
       ))
     }
-    tmp_path <- paste0(path, ".tmp")
+    tmp_path <- paste0(path, ".", Sys.getpid(), ".tmp")
     jsonlite::write_json(data, tmp_path, auto_unbox = TRUE, digits = 6)
     file.rename(tmp_path, path)
     invisible(n_rows)

--- a/inst/scripts/refresh_codex_cache.R
+++ b/inst/scripts/refresh_codex_cache.R
@@ -522,6 +522,33 @@ aggregate_daily <- function(turns) {
     arrange(date)
 }
 
+# ── Helper: atomic JSON write via temp-file rename ────────────────────────────
+# Writes to a sibling .<pid>.tmp file then renames atomically so that a SIGKILL /
+# disk-full mid-write cannot truncate the production file.  Also asserts that
+# the combined row count is monotone (>= existing) before writing so that an
+# accidental upstream parse failure cannot silently truncate history.
+# Defined at top level (not inside if (!interactive())) so tests can call it
+# directly without reproducing the logic inline.
+write_json_atomic <- function(data, path, min_rows = 0L, label = basename(path)) {
+  n_rows <- nrow(data)
+  if (n_rows < min_rows &&
+      !isTRUE(as.logical(Sys.getenv("ALLOW_SHRINK", "false")))) {
+    cli::cli_abort(c(
+      "x" = "Refusing to write {label}: row count would shrink.",
+      "i" = "Existing rows: {min_rows}; new combined rows: {n_rows}.",
+      "i" = "This indicates an upstream parse failure — aborting to protect history.",
+      "i" = "Set ALLOW_SHRINK=1 to bypass the monotonicity guard."
+    ))
+  }
+  tmp_path <- paste0(path, ".", Sys.getpid(), ".tmp")
+  on.exit(if (file.exists(tmp_path)) unlink(tmp_path, force = TRUE), add = TRUE)
+  jsonlite::write_json(data, tmp_path, auto_unbox = TRUE, digits = 6)
+  if (!file.rename(tmp_path, path)) {
+    cli::cli_abort("Atomic rename failed: {tmp_path} -> {path}")
+  }
+  invisible(n_rows)
+}
+
 # ── Main ──────────────────────────────────────────────────────────────────────
 if (!interactive()) {
   log_path    <- path.expand("~/.codex/log/codex-tui.log")
@@ -598,29 +625,6 @@ if (!interactive()) {
       distinct(thread_id, repo_id, repo_name)
     sessions <- sessions |>
       left_join(repo_info, by = "thread_id")
-  }
-
-  # ── Helper: atomic JSON write via temp-file rename ─────────────────────────
-  # Writes to a sibling .tmp file then renames atomically so that a SIGKILL /
-  # disk-full mid-write cannot truncate the production file.  Also asserts that
-  # the combined row count is monotone (>= existing) before writing so that an
-  # accidental upstream parse failure cannot silently truncate history.
-  write_json_atomic <- function(data, path, min_rows = 0L, label = basename(path)) {
-    n_rows <- nrow(data)
-    if (n_rows < min_rows) {
-      cli::cli_abort(c(
-        "x" = "Refusing to write {label}: row count would shrink.",
-        "i" = "Existing rows: {min_rows}; new combined rows: {n_rows}.",
-        "i" = "This indicates an upstream parse failure — aborting to protect history."
-      ))
-    }
-    tmp_path <- paste0(path, ".", Sys.getpid(), ".tmp")
-    on.exit(if (file.exists(tmp_path)) unlink(tmp_path, force = TRUE), add = TRUE)
-    jsonlite::write_json(data, tmp_path, auto_unbox = TRUE, digits = 6)
-    if (!file.rename(tmp_path, path)) {
-      cli::cli_abort("Atomic rename failed: {tmp_path} -> {path}")
-    }
-    invisible(n_rows)
   }
 
   # Read existing sessions and merge (incremental update)

--- a/inst/scripts/refresh_codex_cache.R
+++ b/inst/scripts/refresh_codex_cache.R
@@ -615,6 +615,7 @@ if (!interactive()) {
       ))
     }
     tmp_path <- paste0(path, ".", Sys.getpid(), ".tmp")
+    on.exit(if (file.exists(tmp_path)) unlink(tmp_path, force = TRUE), add = TRUE)
     jsonlite::write_json(data, tmp_path, auto_unbox = TRUE, digits = 6)
     file.rename(tmp_path, path)
     invisible(n_rows)

--- a/tests/testthat/_snaps/canonicalize.md
+++ b/tests/testthat/_snaps/canonicalize.md
@@ -1,0 +1,16 @@
+# dash-form, slash-form, underscore-path, and bare-underscore snapshot
+
+    Code
+      result
+    Output
+      [1] "llmtelemetry"       "llmtelemetry"       "llmtelemetry"      
+      [4] "llm"                NA                   "irish_buoy_network"
+
+# .shorten_project_local snapshot — output for known forms is stable
+
+    Code
+      result
+    Output
+      [1] "llmtelemetry"   "llmtelemetry"   "llm"            "llm"           
+      [5] "urban_planning"
+

--- a/tests/testthat/_snaps/canonicalize.md
+++ b/tests/testthat/_snaps/canonicalize.md
@@ -1,3 +1,10 @@
+# mixed dash-underscore snapshot
+
+    Code
+      .canonicalize_project_local(inputs)
+    Output
+      [1] "llmtelemetry" "llmtelemetry"
+
 # dash-form, slash-form, underscore-path, and bare-underscore snapshot
 
     Code

--- a/tests/testthat/_snaps/export-dashboard-data.md
+++ b/tests/testthat/_snaps/export-dashboard-data.md
@@ -1,0 +1,22 @@
+# export_dashboard_data.R CI fallback copies ccusage_daily.json (not ccusage_daily_all.json)
+
+    Code
+      block_lines
+    Output
+       [1] "  fallback_daily_src <- file.path(extdata, \"ccusage_daily.json\")"                             
+       [2] "  fallback_daily_dst <- file.path(out_dir, \"ccusage_daily.json\")"                             
+       [3] "  if (file.exists(fallback_daily_src)) {"                                                       
+       [4] "    file.copy(fallback_daily_src, fallback_daily_dst, overwrite = TRUE)"                        
+       [5] "    cat(\"  -> copied ccusage_daily.json (CI fallback)\\n\")"                                   
+       [6] "  } else if (!file.exists(fallback_daily_dst)) {"                                               
+       [7] "    write_json(list(), fallback_daily_dst, auto_unbox = TRUE)"                                  
+       [8] "    cat(\"  -> ccusage_daily.json not found, wrote empty (CI fallback)\\n\")"                   
+       [9] "  }"                                                                                            
+      [10] "  if (!file.exists(file.path(out_dir, \"ccusage_sessions.json\"))) {"                           
+      [11] "    write_json(list(), file.path(out_dir, \"ccusage_sessions.json\"), auto_unbox = TRUE)"       
+      [12] "    cat(\"  -> wrote empty ccusage_sessions.json (CI fallback; cmonitor-rs not available)\\n\")"
+      [13] "  }"                                                                                            
+      [14] "  if (!file.exists(file.path(out_dir, \"ccusage_blocks.json\"))) {"                             
+      [15] "    write_json(list(), file.path(out_dir, \"ccusage_blocks.json\"), auto_unbox = TRUE)"         
+      [16] "    cat(\"  -> wrote empty ccusage_blocks.json (CI fallback; cmonitor-rs not available)\\n\")"  
+

--- a/tests/testthat/_snaps/refresh-codex-cache.md
+++ b/tests/testthat/_snaps/refresh-codex-cache.md
@@ -48,3 +48,13 @@
       [1] "canonical_project" "model"             "repo_id"          
       [4] "repo_name"         "source"            "thread_id"        
 
+# merge logic aborts when new sessions tibble is empty and existing has rows
+
+    Code
+      guard_fn(0L, 5L, "codex_sessions.json")
+    Condition
+      Error in `guard_fn()`:
+      x Refusing to write codex_sessions.json: row count would shrink.
+      i Existing rows: 5; new combined rows: 0.
+      i This indicates an upstream parse failure — aborting to protect history.
+

--- a/tests/testthat/_snaps/refresh-codex-cache.md
+++ b/tests/testthat/_snaps/refresh-codex-cache.md
@@ -48,13 +48,14 @@
       [1] "canonical_project" "model"             "repo_id"          
       [4] "repo_name"         "source"            "thread_id"        
 
-# merge logic aborts when new sessions tibble is empty and existing has rows
+# write_json_atomic aborts when row count shrinks below min_rows
 
     Code
-      guard_fn(0L, 5L, "codex_sessions.json")
+      write_json_atomic(empty_data, out_path, min_rows = 5L, label = "codex_sessions.json")
     Condition
-      Error in `guard_fn()`:
+      Error in `write_json_atomic()`:
       x Refusing to write codex_sessions.json: row count would shrink.
       i Existing rows: 5; new combined rows: 0.
       i This indicates an upstream parse failure — aborting to protect history.
+      i Set ALLOW_SHRINK=1 to bypass the monotonicity guard.
 

--- a/tests/testthat/test-canonicalize-consistency.R
+++ b/tests/testthat/test-canonicalize-consistency.R
@@ -11,8 +11,12 @@ local({
                   mustWork = TRUE),
     error = function(e) ""
   )
+  assigned_names <- character(0L)
   if (nzchar(r_file) && file.exists(r_file)) {
     source(r_file, local = FALSE)
+    assigned_names <- c(".shorten_project_local",
+                        ".canonicalize_project_local",
+                        ".canonicalize_project_local_scalar")
   } else {
     assign(".shorten_project_local",
            llmtelemetry:::.shorten_project_local, envir = .GlobalEnv)
@@ -20,7 +24,16 @@ local({
            llmtelemetry:::.canonicalize_project_local, envir = .GlobalEnv)
     assign(".canonicalize_project_local_scalar",
            llmtelemetry:::.canonicalize_project_local_scalar, envir = .GlobalEnv)
+    assigned_names <- c(".shorten_project_local",
+                        ".canonicalize_project_local",
+                        ".canonicalize_project_local_scalar")
   }
+  # Restore .GlobalEnv when the test file finishes.
+  withr::defer(
+    rm(list = intersect(assigned_names, ls(envir = .GlobalEnv, all.names = TRUE)),
+       envir = .GlobalEnv),
+    envir = testthat::teardown_env()
+  )
 })
 
 # Export script helper (extract scalar function + shorten_project)

--- a/tests/testthat/test-canonicalize-consistency.R
+++ b/tests/testthat/test-canonicalize-consistency.R
@@ -3,9 +3,25 @@
 # must produce identical canonical names for historically split project names.
 
 # ── Load both implementations ─────────────────────────────────────────────────
-# Local R package helper
-pkg_root <- normalizePath(file.path(test_path(), "..", ".."), mustWork = FALSE)
-source(file.path(pkg_root, "R", "canonicalize.R"), local = TRUE)
+# Local R package helper: try development tree first, fall back to package
+# namespace for R CMD check compatibility.
+local({
+  r_file <- tryCatch(
+    normalizePath(file.path(test_path(), "..", "..", "R", "canonicalize.R"),
+                  mustWork = TRUE),
+    error = function(e) ""
+  )
+  if (nzchar(r_file) && file.exists(r_file)) {
+    source(r_file, local = FALSE)
+  } else {
+    assign(".shorten_project_local",
+           llmtelemetry:::.shorten_project_local, envir = .GlobalEnv)
+    assign(".canonicalize_project_local",
+           llmtelemetry:::.canonicalize_project_local, envir = .GlobalEnv)
+    assign(".canonicalize_project_local_scalar",
+           llmtelemetry:::.canonicalize_project_local_scalar, envir = .GlobalEnv)
+  }
+})
 
 # Export script helper (extract scalar function + shorten_project)
 get_export_canonicalize_fn <- function() {

--- a/tests/testthat/test-canonicalize.R
+++ b/tests/testthat/test-canonicalize.R
@@ -8,8 +8,26 @@
 # Finding (c) in roborev round V: underscore-form nested paths were not
 # converted and polluted canonical_project with tokens like "docs_gh_llm".
 
-pkg_root <- normalizePath(file.path(test_path(), "..", ".."), mustWork = FALSE)
-source(file.path(pkg_root, "R", "canonicalize.R"), local = TRUE)
+# Load canonicalize helpers: try source from development tree first (devtools
+# test workflow), fall back to package namespace (R CMD check workflow).
+local({
+  r_file <- tryCatch(
+    normalizePath(file.path(test_path(), "..", "..", "R", "canonicalize.R"),
+                  mustWork = TRUE),
+    error = function(e) ""
+  )
+  if (nzchar(r_file) && file.exists(r_file)) {
+    source(r_file, local = FALSE)
+  } else {
+    # In R CMD check, functions are available via the package namespace.
+    assign(".shorten_project_local",
+           llmtelemetry:::.shorten_project_local, envir = .GlobalEnv)
+    assign(".canonicalize_project_local",
+           llmtelemetry:::.canonicalize_project_local, envir = .GlobalEnv)
+    assign(".canonicalize_project_local_scalar",
+           llmtelemetry:::.canonicalize_project_local_scalar, envir = .GlobalEnv)
+  }
+})
 
 # ── Dash-form (existing behaviour, must not regress) ──────────────────────────
 

--- a/tests/testthat/test-canonicalize.R
+++ b/tests/testthat/test-canonicalize.R
@@ -16,8 +16,14 @@ local({
                   mustWork = TRUE),
     error = function(e) ""
   )
+  # Names assigned to .GlobalEnv by either branch; cleaned up via teardown_env.
+  assigned_names <- character(0L)
   if (nzchar(r_file) && file.exists(r_file)) {
     source(r_file, local = FALSE)
+    # source() assigns all top-level names; schedule removal of the known ones.
+    assigned_names <- c(".shorten_project_local",
+                        ".canonicalize_project_local",
+                        ".canonicalize_project_local_scalar")
   } else {
     # In R CMD check, functions are available via the package namespace.
     assign(".shorten_project_local",
@@ -26,7 +32,16 @@ local({
            llmtelemetry:::.canonicalize_project_local, envir = .GlobalEnv)
     assign(".canonicalize_project_local_scalar",
            llmtelemetry:::.canonicalize_project_local_scalar, envir = .GlobalEnv)
+    assigned_names <- c(".shorten_project_local",
+                        ".canonicalize_project_local",
+                        ".canonicalize_project_local_scalar")
   }
+  # Restore .GlobalEnv when the test file finishes.
+  withr::defer(
+    rm(list = intersect(assigned_names, ls(envir = .GlobalEnv, all.names = TRUE)),
+       envir = .GlobalEnv),
+    envir = testthat::teardown_env()
+  )
 })
 
 # ── Dash-form (existing behaviour, must not regress) ──────────────────────────

--- a/tests/testthat/test-canonicalize.R
+++ b/tests/testthat/test-canonicalize.R
@@ -69,6 +69,20 @@ test_that("underscore-form -Users_ full prefix is stripped", {
   )
 })
 
+# ── Mixed dash-and-underscore separator forms (critic m9) ────────────────────
+
+test_that("mixed dash-underscore forms docs-gh_<project> and docs_gh-<project> normalise correctly", {
+  # "docs-gh_llmtelemetry": docs-gh_ prefix (dash then underscore)
+  expect_equal(.canonicalize_project_local("docs-gh_llmtelemetry"), "llmtelemetry")
+  # "docs_gh-llmtelemetry": docs_gh- prefix (underscore then dash)
+  expect_equal(.canonicalize_project_local("docs_gh-llmtelemetry"), "llmtelemetry")
+})
+
+test_that("mixed dash-underscore snapshot", {
+  inputs <- c("docs-gh_llmtelemetry", "docs_gh-llmtelemetry")
+  expect_snapshot(.canonicalize_project_local(inputs))
+})
+
 # ── Bare underscore names must pass through UNCHANGED (meta_only guard) ───────
 
 test_that("bare 'urban_planning' remains NA (meta_only)", {

--- a/tests/testthat/test-canonicalize.R
+++ b/tests/testthat/test-canonicalize.R
@@ -1,0 +1,100 @@
+# Tests for R/canonicalize.R internal helpers.
+#
+# Covers:
+#   .shorten_project_local()           — path-prefix normalisation
+#   .canonicalize_project_local()      — vectorised scalar wrapper
+#   .canonicalize_project_local_scalar()
+#
+# Finding (c) in roborev round V: underscore-form nested paths were not
+# converted and polluted canonical_project with tokens like "docs_gh_llm".
+
+pkg_root <- normalizePath(file.path(test_path(), "..", ".."), mustWork = FALSE)
+source(file.path(pkg_root, "R", "canonicalize.R"), local = TRUE)
+
+# ── Dash-form (existing behaviour, must not regress) ──────────────────────────
+
+test_that("dash-form hook path is normalised to project name", {
+  expect_equal(.canonicalize_project_local("docs-gh-llmtelemetry"), "llmtelemetry")
+  expect_equal(.canonicalize_project_local("docs-gh-llm"),          "llm")
+  expect_equal(.canonicalize_project_local("docs-gh-mycare"),        "mycare")
+})
+
+test_that("full dash-form -Users- prefix is stripped", {
+  expect_equal(
+    .canonicalize_project_local("-Users-johngavin-docs-gh-llmtelemetry"),
+    "llmtelemetry"
+  )
+})
+
+# ── Slash-form (pre-converted input, must not regress) ────────────────────────
+
+test_that("slash-form path returns first real segment", {
+  # "docs/gh/llmtelemetry": "docs" is not a container prefix so first segment
+  # "docs" is returned.  This is the existing behaviour; use known forms for
+  # regression tests.
+  expect_equal(.canonicalize_project_local("llmtelemetry/inst"),         "llmtelemetry")
+  expect_equal(.canonicalize_project_local("simulations/randomwalk"),    "randomwalk")
+})
+
+# ── Underscore-form nested paths (finding c: new behaviour) ──────────────────
+
+test_that("underscore-form docs_gh_ prefix is stripped to project name", {
+  expect_equal(.canonicalize_project_local("docs_gh_llmtelemetry"), "llmtelemetry")
+  expect_equal(.canonicalize_project_local("docs_gh_llm"),          "llm")
+  expect_equal(.canonicalize_project_local("docs_gh_mycare"),        "mycare")
+})
+
+test_that("underscore-form -Users_ full prefix is stripped", {
+  expect_equal(
+    .canonicalize_project_local("-Users_johngavin_docs_gh_llmtelemetry"),
+    "llmtelemetry"
+  )
+})
+
+# ── Bare underscore names must pass through UNCHANGED (meta_only guard) ───────
+
+test_that("bare 'urban_planning' remains NA (meta_only)", {
+  # Regression guard: underscore-to-slash conversion must not fire for bare
+  # single-token names that are not path-like.  'urban_planning' is in meta_only
+  # and must resolve to NA_character_, not "urban/planning" -> "urban".
+  expect_equal(.canonicalize_project_local("urban_planning"), NA_character_)
+})
+
+test_that("bare 'irish_buoy_network' is not converted by underscore logic", {
+  # This name is NOT in meta_only — it maps via the overrides list once it is
+  # in slash form.  Bare underscore form must not reach the override checks
+  # after incorrect conversion.  Since "irish_buoy_network" does NOT start with
+  # a path-like prefix, .shorten_project_local() leaves it intact; the scalar
+  # helper then returns the first segment "irish_buoy_network" which passes
+  # the meta_only check and is returned as-is.
+  result <- .canonicalize_project_local("irish_buoy_network")
+  expect_false(is.na(result))
+  expect_equal(result, "irish_buoy_network")
+})
+
+# ── Snapshot tests ────────────────────────────────────────────────────────────
+
+test_that("dash-form, slash-form, underscore-path, and bare-underscore snapshot", {
+  inputs <- c(
+    "docs-gh-llmtelemetry",                      # dash-form
+    "llmtelemetry/inst",                         # slash-form (already normalised)
+    "docs_gh_llmtelemetry",                      # underscore-path
+    "-Users_johngavin_docs_gh_llm",              # underscore full prefix
+    "urban_planning",                            # bare underscore name (meta_only -> NA)
+    "irish_buoy_network"                         # bare underscore name (not meta_only)
+  )
+  result <- .canonicalize_project_local(inputs)
+  expect_snapshot(result)
+})
+
+test_that(".shorten_project_local snapshot — output for known forms is stable", {
+  inputs <- c(
+    "docs-gh-llmtelemetry",          # dash-form -> "llmtelemetry"
+    "docs_gh_llmtelemetry",          # underscore-path -> "llmtelemetry"
+    "-Users-johngavin-docs-gh-llm",  # dash full prefix -> "llm"
+    "-Users_johngavin_docs_gh_llm",  # underscore full prefix -> "llm"
+    "urban_planning"                 # bare underscore name -> unchanged
+  )
+  result <- vapply(inputs, .shorten_project_local, character(1L), USE.NAMES = FALSE)
+  expect_snapshot(result)
+})

--- a/tests/testthat/test-canonicalize.R
+++ b/tests/testthat/test-canonicalize.R
@@ -104,6 +104,19 @@ test_that("bare 'irish_buoy_network' is not converted by underscore logic", {
   expect_equal(result, "irish_buoy_network")
 })
 
+# ── Path-prefix + underscore meta_only names (critic m10) ────────────────────
+
+test_that("path-prefixed docs_gh_urban_planning resolves to NA (meta_only)", {
+  # docs_gh_urban_planning: the ^docs[-_]gh[-_] prefix is stripped first,
+  # yielding "urban_planning" which is in meta_only -> NA_character_.
+  expect_equal(.canonicalize_project_local("docs_gh_urban_planning"), NA_character_)
+})
+
+test_that("path-prefixed docs_gh_telemetry resolves to NA (meta_only)", {
+  # docs_gh_telemetry: strips to "telemetry" which is in meta_only -> NA_character_.
+  expect_equal(.canonicalize_project_local("docs_gh_telemetry"), NA_character_)
+})
+
 # ── Snapshot tests ────────────────────────────────────────────────────────────
 
 test_that("dash-form, slash-form, underscore-path, and bare-underscore snapshot", {

--- a/tests/testthat/test-export-dashboard-data.R
+++ b/tests/testthat/test-export-dashboard-data.R
@@ -380,27 +380,58 @@ test_that("ccusage_daily.json is valid JSON and a flat array (data.frame)", {
   )
 })
 
-test_that("export_dashboard_data.R CI fallback uses ccusage_daily.json not ccusage_daily_all.json", {
+test_that("export_dashboard_data.R CI fallback copies ccusage_daily.json (not ccusage_daily_all.json)", {
+  # Rewritten from the old fallback_map regex test (roborev round V/d).
+  # The script no longer has a fallback_map list — it copies files directly.
+  # We parse the CI fallback block to verify:
+  #   (i)  The source file is ccusage_daily.json (not ccusage_daily_all.json)
+  #   (ii) ccusage_daily_all.json does NOT appear as the source of any file.copy call
+  #
+  # Strategy: find the `fallback_daily_src <- ...` assignment line, extract the
+  # filename string, and assert it equals "ccusage_daily.json".
   script_path <- system.file("scripts", "export_dashboard_data.R",
                              package = "llmtelemetry")
   skip_if(!nzchar(script_path), "export_dashboard_data.R not installed")
   lines <- readLines(script_path)
-  fallback_block <- grep("fallback_map", lines)
-  skip_if(length(fallback_block) == 0, "fallback_map not found in export script")
-  # The CI fallback must copy ccusage_daily.json (not ccusage_daily_all.json)
-  # to avoid serving a stale/renamed source file.
-  block_lines <- lines[seq(max(1, min(fallback_block) - 2),
-                           min(length(lines), max(fallback_block) + 10))]
+
+  # Find the line that assigns the CI fallback source file
+  src_line_idx <- grep("fallback_daily_src\\s*<-", lines)
+  skip_if(length(src_line_idx) == 0L,
+          "fallback_daily_src assignment not found in export_dashboard_data.R")
+
+  # Extract the block: from src assignment to the matching dst copy, max 10 lines
+  block_start <- src_line_idx[1L]
+  block_end   <- min(length(lines), block_start + 15L)
+  block_lines <- lines[block_start:block_end]
+  block_text  <- paste(block_lines, collapse = "\n")
+
+  # Parse the block to extract the source filename
+  # The line looks like: fallback_daily_src <- file.path(extdata, "ccusage_daily.json")
+  # Extract the quoted filename from the file.path() call
+  src_match <- regmatches(block_text,
+    regexpr('"([^"]+\\.json)"', block_text, perl = TRUE))
+  src_filename <- if (length(src_match) > 0L) gsub('"', '', src_match[1L]) else NA_character_
+
+  # (i) Source must be ccusage_daily.json (not ccusage_daily_all.json)
+  expect_equal(
+    src_filename,
+    "ccusage_daily.json",
+    info = paste("CI fallback source must be 'ccusage_daily.json'.",
+                 "Using 'ccusage_daily_all.json' (old nested format) is a regression",
+                 "(PR #93 changed the schema). Found:", src_filename)
+  )
+
+  # (ii) ccusage_daily_all.json must not appear as a source for file.copy or
+  #       file.path() calls that copy data to the public output.
+  #       (Comments explaining why NOT to use it are acceptable.)
+  non_comment_lines <- grep("^\\s*#", lines, invert = TRUE, value = TRUE)
   expect_false(
-    any(grepl('"ccusage_daily_all\\.json"\\s*=\\s*"ccusage_daily\\.json"',
-              block_lines)),
-    info = paste("fallback_map still maps ccusage_daily_all.json -> ccusage_daily.json.",
-                 "PR #93 changed the source key to ccusage_daily.json directly.",
-                 "Revert to ccusage_daily_all.json = 'ccusage_daily.json' is a regression.")
+    any(grepl("ccusage_daily_all\\.json", non_comment_lines)),
+    info = paste("'ccusage_daily_all.json' must not appear in non-comment code.",
+                 "PR #93 renamed/removed this file to eliminate the nested-format schema.",
+                 "Any non-comment reference to it is a regression.")
   )
-  expect_true(
-    any(grepl('"ccusage_daily\\.json"\\s*=\\s*"ccusage_daily\\.json"', block_lines)),
-    info = paste("fallback_map must map 'ccusage_daily.json' -> 'ccusage_daily.json'",
-                 "so the committed extdata file is used directly as the CI fallback.")
-  )
+
+  # Snapshot the block so future changes to CI fallback logic surface explicitly
+  expect_snapshot(block_lines)
 })

--- a/tests/testthat/test-refresh-codex-cache.R
+++ b/tests/testthat/test-refresh-codex-cache.R
@@ -475,7 +475,7 @@ test_that("join_roborev snapshot — column names after join are stable", {
 # ── write_json_atomic: monotonicity guard + atomic write ──────────────────────
 
 test_that("merge logic is monotone: existing sessions are preserved when new sessions are added", {
-  skip_if(is.null(aggregate_daily), "aggregate_daily not found (script not sourced)")
+  skip_if(is.null(aggregate_daily), "aggregate_daily not found (script not sourced — dplyr may not be available)")
 
   tmp_dir <- withr::local_tempdir()
 

--- a/tests/testthat/test-refresh-codex-cache.R
+++ b/tests/testthat/test-refresh-codex-cache.R
@@ -534,6 +534,33 @@ test_that("write_json_atomic aborts when row count shrinks below min_rows", {
   )
 })
 
+test_that("ALLOW_SHRINK=1 bypasses the monotonicity guard", {
+  # Regression for critic M6: escape hatch for deliberate shrinks
+  # (e.g. backfill from scratch, administrative reset).
+  skip_if(is.null(write_json_atomic),
+          "write_json_atomic not found (script not sourced)")
+
+  tmp_dir  <- withr::local_tempdir()
+  out_path <- file.path(tmp_dir, "codex_sessions.json")
+
+  # Pre-populate with 5 rows
+  jsonlite::write_json(
+    tibble::tibble(x = 1:5), out_path, auto_unbox = TRUE
+  )
+
+  # Write only 2 rows — would normally abort without ALLOW_SHRINK
+  small_data <- tibble::tibble(x = 1:2)
+  withr::with_envvar(
+    c(ALLOW_SHRINK = "1"),
+    expect_no_error(
+      write_json_atomic(small_data, out_path, min_rows = 5L,
+                        label = "codex_sessions.json")
+    )
+  )
+  result <- jsonlite::fromJSON(out_path, simplifyDataFrame = TRUE)
+  expect_equal(nrow(result), 2L)
+})
+
 test_that("write_json_atomic writes correctly and leaves no .tmp file on success", {
   skip_if(is.null(write_json_atomic),
           "write_json_atomic not found (script not sourced)")

--- a/tests/testthat/test-refresh-codex-cache.R
+++ b/tests/testthat/test-refresh-codex-cache.R
@@ -471,3 +471,87 @@ test_that("join_roborev snapshot — column names after join are stable", {
   suppressMessages(result <- join_roborev(turns))
   expect_snapshot(sort(names(result)))
 })
+
+# ── write_json_atomic: monotonicity guard + atomic write ──────────────────────
+
+test_that("merge logic is monotone: existing sessions are preserved when new sessions are added", {
+  skip_if(is.null(aggregate_daily), "aggregate_daily not found (script not sourced)")
+
+  tmp_dir <- withr::local_tempdir()
+
+  # Simulate existing sessions JSON on disk
+  existing_data <- tibble::tibble(
+    thread_id         = c("thread-001", "thread-002"),
+    started_at        = c("2026-05-01T10:00:00Z", "2026-05-02T12:00:00Z"),
+    ended_at          = c("2026-05-01T10:30:00Z", "2026-05-02T12:30:00Z"),
+    canonical_project = c("llm", "llm"),
+    model             = c("gpt-5.4", "gpt-5.4"),
+    n_turns           = c(3L, 5L)
+  )
+  sessions_path <- file.path(tmp_dir, "codex_sessions.json")
+  jsonlite::write_json(existing_data, sessions_path, auto_unbox = TRUE)
+
+  # New session (does not overlap with existing)
+  new_sessions <- tibble::tibble(
+    thread_id         = "thread-003",
+    started_at        = "2026-05-03T09:00:00Z",
+    ended_at          = "2026-05-03T09:45:00Z",
+    canonical_project = "llm",
+    model             = "gpt-5.4",
+    n_turns           = 2L
+  )
+
+  # Replicate the merge logic from refresh_codex_cache.R
+  existing_sessions <- jsonlite::fromJSON(sessions_path, simplifyDataFrame = TRUE)
+  n_existing <- nrow(existing_sessions)
+  all_sessions <- dplyr::bind_rows(
+    dplyr::filter(existing_sessions, !thread_id %in% new_sessions$thread_id),
+    new_sessions
+  )
+
+  # Row count must not shrink
+  expect_gte(nrow(all_sessions), n_existing)
+  expect_equal(nrow(all_sessions), 3L)
+})
+
+test_that("merge logic aborts when new sessions tibble is empty and existing has rows", {
+  # Simulate write_json_atomic monotonicity guard: if combined rows < existing rows,
+  # the guard fires. This test verifies the guard message text via snapshot.
+  skip_if(is.null(aggregate_daily), "aggregate_daily not found (script not sourced)")
+
+  # write_json_atomic guard: min_rows = 5 but data has 0 rows
+  # Reproduce the guard inline (the function is script-local, not exported).
+  guard_fn <- function(n_rows, min_rows, label) {
+    if (n_rows < min_rows) {
+      cli::cli_abort(c(
+        "x" = "Refusing to write {label}: row count would shrink.",
+        "i" = "Existing rows: {min_rows}; new combined rows: {n_rows}.",
+        "i" = "This indicates an upstream parse failure — aborting to protect history."
+      ))
+    }
+    invisible(n_rows)
+  }
+
+  expect_snapshot(
+    error = TRUE,
+    guard_fn(0L, 5L, "codex_sessions.json")
+  )
+})
+
+test_that("atomic write uses .tmp then renames — no partial file on success", {
+  skip_if(is.null(aggregate_daily), "aggregate_daily not found (script not sourced)")
+
+  tmp_dir <- withr::local_tempdir()
+  target  <- file.path(tmp_dir, "test_output.json")
+  tmp_tmp <- paste0(target, ".tmp")
+
+  data <- tibble::tibble(x = 1:3)
+  # Atomic write pattern: write to .tmp then rename
+  jsonlite::write_json(data, tmp_tmp, auto_unbox = TRUE)
+  file.rename(tmp_tmp, target)
+
+  expect_true(file.exists(target))
+  expect_false(file.exists(tmp_tmp))
+  result <- jsonlite::fromJSON(target, simplifyDataFrame = TRUE)
+  expect_equal(nrow(result), 3L)
+})

--- a/tests/testthat/test-refresh-codex-cache.R
+++ b/tests/testthat/test-refresh-codex-cache.R
@@ -514,44 +514,40 @@ test_that("merge logic is monotone: existing sessions are preserved when new ses
   expect_equal(nrow(all_sessions), 3L)
 })
 
-test_that("merge logic aborts when new sessions tibble is empty and existing has rows", {
-  # Simulate write_json_atomic monotonicity guard: if combined rows < existing rows,
-  # the guard fires. This test verifies the guard message text via snapshot.
-  skip_if(is.null(aggregate_daily), "aggregate_daily not found (script not sourced)")
+test_that("write_json_atomic aborts when row count shrinks below min_rows", {
+  # Verify the monotonicity guard in the real write_json_atomic function.
+  skip_if(is.null(write_json_atomic),
+          "write_json_atomic not found (script not sourced)")
 
-  # write_json_atomic guard: min_rows = 5 but data has 0 rows
-  # Reproduce the guard inline (the function is script-local, not exported).
-  guard_fn <- function(n_rows, min_rows, label) {
-    if (n_rows < min_rows) {
-      cli::cli_abort(c(
-        "x" = "Refusing to write {label}: row count would shrink.",
-        "i" = "Existing rows: {min_rows}; new combined rows: {n_rows}.",
-        "i" = "This indicates an upstream parse failure — aborting to protect history."
-      ))
-    }
-    invisible(n_rows)
-  }
+  tmp_dir  <- withr::local_tempdir()
+  out_path <- file.path(tmp_dir, "codex_sessions.json")
 
+  # Pre-populate the file so the rename target is valid
+  jsonlite::write_json(
+    tibble::tibble(x = 1:5), out_path, auto_unbox = TRUE
+  )
+
+  empty_data <- tibble::tibble(x = integer(0))
   expect_snapshot(
     error = TRUE,
-    guard_fn(0L, 5L, "codex_sessions.json")
+    write_json_atomic(empty_data, out_path, min_rows = 5L, label = "codex_sessions.json")
   )
 })
 
-test_that("atomic write uses .tmp then renames — no partial file on success", {
-  skip_if(is.null(aggregate_daily), "aggregate_daily not found (script not sourced)")
+test_that("write_json_atomic writes correctly and leaves no .tmp file on success", {
+  skip_if(is.null(write_json_atomic),
+          "write_json_atomic not found (script not sourced)")
 
   tmp_dir <- withr::local_tempdir()
   target  <- file.path(tmp_dir, "test_output.json")
-  tmp_tmp <- paste0(target, ".tmp")
 
   data <- tibble::tibble(x = 1:3)
-  # Atomic write pattern: write to .tmp then rename
-  jsonlite::write_json(data, tmp_tmp, auto_unbox = TRUE)
-  file.rename(tmp_tmp, target)
+  write_json_atomic(data, target)
 
   expect_true(file.exists(target))
-  expect_false(file.exists(tmp_tmp))
+  # No PID-suffixed .tmp files should remain
+  tmp_files <- list.files(tmp_dir, pattern = "\\.tmp$", full.names = TRUE)
+  expect_length(tmp_files, 0L)
   result <- jsonlite::fromJSON(target, simplifyDataFrame = TRUE)
   expect_equal(nrow(result), 3L)
 })


### PR DESCRIPTION
## Summary

Non-breaking subset of roborev round V findings + 9 critic-round fixes that touch the same files.

This PR is an ALTERNATIVE to #134 (which bundles all 17 commits — original 5 + 12 critic fixes). Merging #135 + #136 = same final state as merging #134.

### Original (4)
| # | Severity | Area |
|---|---|---|
| a | HIGH | `inst/scripts/refresh_codex_cache.R` — atomic write + monotonicity guard |
| c | MEDIUM | `R/canonicalize.R` — underscore-form nested paths |
| d | LOW | `tests/testthat/test-export-dashboard-data.R` — parse-based fallback_map test |
| infra | — | R CMD check repair for canonicalize tests |

### Critic-round (9)
- C1 PID-unique `.tmp` filename
- C2 cleanup `.tmp` on write_json failure
- C3 check `file.rename()` return value
- M5 hoist `write_json_atomic` out of `!interactive()` block
- M6 `ALLOW_SHRINK=1` escape hatch for monotonicity guard
- M7 (canonicalize portion) restore `.GlobalEnv` after test-helper assigns
- m9 mixed dash-underscore separator form tests
- m10 path-prefixed meta_only name tests
- m12 clarify skip messages for atomic-write tests

## Test plan
- [ ] CI passes
- [ ] Roborev review clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
