### PR TITLE
fix(canonicalize): underscore-form irishbuoys override (closes #142)

### DIFF
--- a/R/canonicalize.R
+++ b/R/canonicalize.R
@@ -43,12 +43,16 @@
 
   # Explicit prefix overrides — checked before container-prefix strip.
   overrides <- list(
-    "buoy/network"                   = "irish_buoy_network",
-    "irishbuoys"                     = "irish_buoy_network",
+    "buoy/network"                    = "irish_buoy_network",
+    "irishbuoys"                      = "irish_buoy_network",
     # raw path proj-data-weather-irish-buoy-network -> data/weather/irish/buoy/network
     "data/weather/irish/buoy/network" = "irish_buoy_network",
-    # after data/ strip: weather/irish/buoy/network
-    "weather/irish/buoy/network"     = "irish_buoy_network"
+    # underscore form used in tracked repo paths: data/weather/irish_buoy_network/...
+    "data/weather/irish_buoy_network" = "irish_buoy_network",
+    # after data/ strip: weather/irish/buoy/network (dash form)
+    "weather/irish/buoy/network"      = "irish_buoy_network",
+    # after data/ strip: weather/irish_buoy_network/... (underscore form)
+    "weather/irish_buoy_network"      = "irish_buoy_network"
   )
   for (pat in names(overrides)) {
     if (startsWith(name, pat)) return(overrides[[pat]])

--- a/tests/testthat/test-canonicalize-consistency.R
+++ b/tests/testthat/test-canonicalize-consistency.R
@@ -91,3 +91,37 @@ test_that("NHS path form canonicalizes to mycare via export canonicalize_session
   nhs_path <- "-Users-johngavin-docs--pers-NHS-health-data-antigravity-mycare"
   expect_equal(export_canonicalize_session(nhs_path), "mycare")
 })
+
+# ── Regression: Issue #142 — underscore-form irishbuoys path ─────────────────
+# data/weather/irish_buoy_network/irishbuoys (underscore form, used in tracked
+# repo paths) was falling through to "weather" before this fix.
+test_that("underscore-form irishbuoys nested path canonicalises to irish_buoy_network (#142)", {
+  # The primary bug case: underscore form with data/ prefix
+  expect_equal(
+    .canonicalize_project_local("data/weather/irish_buoy_network/irishbuoys"),
+    "irish_buoy_network"
+  )
+  # After data/ strip only
+  expect_equal(
+    .canonicalize_project_local("weather/irish_buoy_network/irishbuoys"),
+    "irish_buoy_network"
+  )
+  # Bare underscore-form prefix (no trailing segment)
+  expect_equal(
+    .canonicalize_project_local("data/weather/irish_buoy_network"),
+    "irish_buoy_network"
+  )
+  expect_equal(
+    .canonicalize_project_local("weather/irish_buoy_network"),
+    "irish_buoy_network"
+  )
+  # Dash form still works (regression guard)
+  expect_equal(
+    .canonicalize_project_local("data/weather/irish/buoy/network"),
+    "irish_buoy_network"
+  )
+  expect_equal(
+    .canonicalize_project_local("weather/irish/buoy/network"),
+    "irish_buoy_network"
+  )
+})


### PR DESCRIPTION
## Summary

Fixes #142 — `data/weather/irish_buoy_network/irishbuoys` was falling through to `"weather"` instead of `"irish_buoy_network"`.

- Adds `"data/weather/irish_buoy_network"` override (pre-strip form)
- Adds `"weather/irish_buoy_network"` override (post-strip form, after `data/` container prefix is removed)
- Regression tests in `test-canonicalize-consistency.R` covering all 4 underscore/dash variants

## Test plan

- [x] `devtools::test(filter = "canonicalize")` → `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 71 ]`
- [x] Manual verification: `.canonicalize_project_local("data/weather/irish_buoy_network/irishbuoys")` → `"irish_buoy_network"`
- [x] Dash-form regression guard still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)