### PR TITLE
fix(email): NaN false positive in bash QA and gate ordering (#137)

### DIFF
--- a/.github/workflows/daily-report.yaml
+++ b/.github/workflows/daily-report.yaml
@@ -33,9 +33,11 @@ jobs:
             any::purrr
             local::.
 
-      - name: Send Report
-        run: Rscript inst/scripts/send_daily_email.R
+      - name: Build email HTML
+        run: Rscript inst/scripts/send_daily_email.R --build-only
 
       - name: Validate email output
-        if: always()
         run: bash inst/scripts/qa_email_output.sh /tmp/email_qa.html
+
+      - name: Send Report
+        run: Rscript inst/scripts/send_daily_email.R

--- a/.github/workflows/daily-report.yaml
+++ b/.github/workflows/daily-report.yaml
@@ -40,4 +40,7 @@ jobs:
         run: bash inst/scripts/qa_email_output.sh /tmp/email_qa.html
 
       - name: Send Report
-        run: Rscript inst/scripts/send_daily_email.R
+        # --send-only reads /tmp/email_qa.html (the validated artifact from the
+        # "Build email HTML" step) and sends that exact content.  This guarantees
+        # the emailed bytes == the QA-validated bytes (fixes roborev Finding 1).
+        run: Rscript inst/scripts/send_daily_email.R --send-only

--- a/R/email_helpers.R
+++ b/R/email_helpers.R
@@ -1,0 +1,53 @@
+# email_helpers.R
+# Shared formatting helpers for daily email report.
+# Sourced by inst/scripts/send_daily_email.R and directly exercised by tests.
+#
+# All helpers treat NaN / NA / Inf / NULL as missing and return a safe fallback
+# string, preventing those tokens from ever reaching sprintf() and appearing as
+# literal "NaN" / "NA" / "Inf" in the emailed HTML.
+
+#' Format a cost value as a USD string.
+#'
+#' @param x Numeric scalar.
+#' @return Character string: "$N.NN" or "-" for missing/non-finite inputs.
+dollar <- function(x) {
+  if (is.null(x) || length(x) == 0) return("-")
+  if (is.na(x) || is.nan(x) || !is.finite(x)) return("-")
+  sprintf("$%.2f", x)
+}
+
+#' Format a number with thousands separator.
+#'
+#' @param x Numeric scalar.
+#' @return Character string or "-" for missing/non-finite inputs.
+comma <- function(x) {
+  if (is.null(x) || length(x) == 0) return("-")
+  if (is.na(x) || is.nan(x) || !is.finite(x)) return("-")
+  format(x, big.mark = ",", scientific = FALSE)
+}
+
+#' Format a token count in millions (e.g. "1.2M").
+#'
+#' @param x Numeric scalar (raw token count).
+#' @return Character string or "-" for missing/non-finite inputs.
+millions <- function(x) {
+  if (is.null(x) || length(x) == 0) return("-")
+  if (is.na(x) || is.nan(x) || !is.finite(x)) return("-")
+  sprintf("%.1fM", x / 1e6)
+}
+
+#' Safe integer formatter for raw count fields (%s slots in sprintf).
+#'
+#' Used for fields like cc_days, gm_days, cm_days, gm_sessions_count,
+#' n_sessions, cx_days, cx_sessions that bypass the dollar/comma/millions
+#' wrappers and are inserted directly via %s.  Without this guard, NaN or NA
+#' would render as the literal string "NaN" or "NA" in the HTML.
+#'
+#' @param x Numeric scalar.
+#' @param fallback Character string returned when x is missing or non-finite.
+#' @return Character string or fallback.
+email_safe_num <- function(x, fallback = "-") {
+  if (is.null(x) || length(x) == 0) return(fallback)
+  if (is.na(x) || is.nan(x) || !is.finite(x)) return(fallback)
+  as.character(as.integer(x))
+}

--- a/inst/scripts/qa_email_output.sh
+++ b/inst/scripts/qa_email_output.sh
@@ -26,9 +26,11 @@ for pat in "Error in" "Error:" "invalid 'trim'" "prettyNum" "object .* not found
   fi
 done
 
-# NaN/NULL — skip inside HTML comments (QA markers may contain "NULL" legitimately)
+# NaN/NULL — skip inside HTML comments (QA markers may contain "NULL" legitimately).
+# Use case-sensitive matching (no -i) to avoid false positives from substrings
+# containing "nan" (e.g. session IDs, project names). Fixes issue #137.
 for pat in "NaN" ">NULL<" "NA_real_"; do
-  COUNT=$(grep -v '<!--' "$FILE" | grep -ci "$pat" || true)
+  COUNT=$(grep -v '<!--' "$FILE" | grep -c "$pat" || true)
   if [ "$COUNT" -gt 0 ]; then
     echo "FAIL: '$pat' in visible content ($COUNT hits)"
     ERRORS=$((ERRORS + COUNT))

--- a/inst/scripts/send_daily_email.R
+++ b/inst/scripts/send_daily_email.R
@@ -1,6 +1,14 @@
 # send_daily_email.R
 # Send daily LLM usage report via Gmail
-# Called from GitHub Actions workflow: .github/workflows/daily-llm-report.yaml
+# Called from GitHub Actions workflow: .github/workflows/daily-report.yaml
+#
+# Flags:
+#   --build-only  Build HTML and write to /tmp/email_qa.html, then exit 0.
+#                 Used by CI to run bash QA before the send step.
+#   (default)     Build, run inline R QA, then send via SMTP.
+
+args <- commandArgs(trailingOnly = TRUE)
+build_only <- "--build-only" %in% args
 
 library(blastula)
 library(dplyr)
@@ -91,18 +99,33 @@ safe_date <- function(x) {
 
 # Helper for formatting
 dollar <- function(x) {
-  if (is.na(x) || is.null(x) || is.nan(x)) return("-")
+  if (is.null(x) || length(x) == 0) return("-")
+  if (is.na(x) || is.nan(x) || !is.finite(x)) return("-")
   sprintf("$%.2f", x)
 }
 comma <- function(x) {
-  if (is.na(x) || is.null(x) || is.nan(x)) return("-")
+  if (is.null(x) || length(x) == 0) return("-")
+  if (is.na(x) || is.nan(x) || !is.finite(x)) return("-")
   format(x, big.mark = ",", scientific = FALSE)
 }
 millions <- function(x) {
-  if (is.na(x) || is.null(x) || is.nan(x)) return("-")
+  if (is.null(x) || length(x) == 0) return("-")
+  if (is.na(x) || is.nan(x) || !is.finite(x)) return("-")
   sprintf("%.1fM", x / 1e6)
 }
-format_hhmm <- function(mins) sprintf("%02d:%02d", as.integer(mins %/% 60), as.integer(mins %% 60))
+# Guard for raw integer/count insertions that bypass dollar/comma/millions.
+# Prevents NaN or NA from reaching sprintf %s slots (cc_days, gm_days, etc).
+email_safe_num <- function(x, fallback = "-") {
+  if (is.null(x) || length(x) == 0) return(fallback)
+  if (is.na(x) || is.nan(x) || !is.finite(x)) return(fallback)
+  as.character(as.integer(x))
+}
+format_hhmm <- function(mins) {
+  if (is.null(mins) || length(mins) == 0 || is.na(mins) || !is.finite(mins)) {
+    return("-:-")
+  }
+  sprintf("%02d:%02d", as.integer(mins %/% 60), as.integer(mins %% 60))
+}
 
 # Dark mode color palette
 dark_bg <- "#1a1a2e"
@@ -559,8 +582,8 @@ if (!has_data) {
   dark_border, dark_text, dollar(cc_cost_day),
   dark_border, accent_blue, millions(total_tokens),
   dark_border, dark_text, millions(cc_tok_day),
-  dark_border, dark_text, cc_days,
-  dark_border, dark_text, n_sessions,
+  dark_border, dark_text, email_safe_num(cc_days, "0"),
+  dark_border, dark_text, email_safe_num(n_sessions, "0"),
   dark_border, dark_text, ifelse(is.na(cc_entries), "-", comma(cc_entries)),
   dark_border, dark_muted, as.character(cc_start),
   dark_border, dark_muted, as.character(cc_end))
@@ -584,8 +607,8 @@ if (!has_data) {
   dark_border, dark_text, dollar(gm_cost_day),
   dark_border, accent_blue, millions(gm_tokens),
   dark_border, dark_text, millions(gm_tok_day),
-  dark_border, dark_text, gm_days,
-  dark_border, dark_text, ifelse(gm_sessions_count == 0, "-", gm_sessions_count),
+  dark_border, dark_text, email_safe_num(gm_days),
+  dark_border, dark_text, email_safe_num(gm_sessions_count, "0"),
   dark_border, dark_text, comma(gm_entries),
   dark_border, dark_muted, as.character(gm_start),
   dark_border, dark_muted, as.character(gm_end))
@@ -609,7 +632,7 @@ if (!has_data) {
   dark_border, dark_text, dollar(cm_cost_day),
   dark_border, accent_blue, millions(cm_tokens),
   dark_border, dark_text, millions(cm_tok_day),
-  dark_border, dark_text, cm_days,
+  dark_border, dark_text, email_safe_num(cm_days),
   dark_border, dark_text, # Sessions (2 placeholders for style, value is hardcoded '-')
   dark_border, dark_text, comma(cm_entries),
   dark_border, dark_muted, as.character(cm_start),
@@ -649,8 +672,8 @@ if (!has_data) {
       dark_border, dark_text, dollar(cx_cost_day),
       dark_border, accent_blue, millions(cx_total_tokens),
       dark_border, dark_text, millions(cx_tok_day),
-      dark_border, dark_text, cx_days,
-      dark_border, dark_text, cx_sessions,
+      dark_border, dark_text, email_safe_num(cx_days, "0"),
+      dark_border, dark_text, email_safe_num(cx_sessions, "0"),
       dark_border, dark_text,
       dark_border, dark_muted, as.character(cx_start),
       dark_border, dark_muted, as.character(cx_end))
@@ -867,6 +890,13 @@ if (!has_data) {
 # Save HTML for CI QA step (always, even if checks pass)
 writeLines(email_body, "/tmp/email_qa.html")
 message("Email HTML saved to /tmp/email_qa.html for QA")
+
+# In --build-only mode (used by CI), exit here so the bash QA step can run
+# before the send step.  The send step reads /tmp/email_qa.html directly.
+if (build_only) {
+  message("--build-only: exiting after HTML build; bash QA will run next")
+  quit(status = 0)
+}
 
 qa_errors <- character(0)
 

--- a/inst/scripts/send_daily_email.R
+++ b/inst/scripts/send_daily_email.R
@@ -4,11 +4,20 @@
 #
 # Flags:
 #   --build-only  Build HTML and write to /tmp/email_qa.html, then exit 0.
-#                 Used by CI to run bash QA before the send step.
-#   (default)     Build, run inline R QA, then send via SMTP.
+#                 Used by CI so the bash QA step can validate before sending.
+#   --send-only   Read /tmp/email_qa.html (already built + QA-validated) and
+#                 send it via SMTP without regenerating.  The emailed bytes are
+#                 EXACTLY the bytes that passed QA.  Used by CI send step.
+#   (default)     Build, run inline R QA, then send via SMTP (local/dev use).
+#
+# CI flow (daily-report.yaml):
+#   1. Rscript send_daily_email.R --build-only   → builds /tmp/email_qa.html
+#   2. bash qa_email_output.sh /tmp/email_qa.html → validates
+#   3. Rscript send_daily_email.R --send-only     → reads & sends same file
 
 args <- commandArgs(trailingOnly = TRUE)
 build_only <- "--build-only" %in% args
+send_only  <- "--send-only"  %in% args
 
 library(blastula)
 library(dplyr)
@@ -19,6 +28,67 @@ library(lubridate)
 library(DBI)
 library(duckdb)
 library(here)
+
+# Source shared formatting helpers (dollar, comma, millions, email_safe_num).
+# here::here() resolves to the package root regardless of cwd at call time.
+source(file.path(here::here(), "R", "email_helpers.R"))
+
+# --send-only: read the already-built + QA-validated HTML and send it.
+# The CI send step uses this flag so the emailed bytes == the validated bytes.
+if (send_only) {
+  qa_file <- "/tmp/email_qa.html"
+  if (!file.exists(qa_file)) {
+    stop("--send-only: /tmp/email_qa.html not found. Run --build-only first.")
+  }
+  email_body <- paste(readLines(qa_file, warn = FALSE), collapse = "\n")
+  message("--send-only: using pre-validated HTML from ", qa_file)
+
+  london_time <- format(Sys.time(), tz = "Europe/London", "%Y-%m-%d %H:%M")
+  dark_muted  <- "#a0a0a0"  # needed for footer only
+  gmail_user  <- Sys.getenv("GMAIL_USERNAME")
+  gmail_pass  <- Sys.getenv("GMAIL_APP_PASSWORD")
+
+  if (gmail_user == "" || gmail_pass == "") {
+    message("WARNING: GMAIL_USERNAME or GMAIL_APP_PASSWORD not set. Skipping email.")
+    cat("\n--- Email Body (send-only, credentials missing) ---\n")
+    cat(email_body)
+    cat("\n----------------------------------------------------\n")
+    quit(status = 0)
+  }
+
+  today <- Sys.Date()
+  email <- compose_email(
+    body   = md(email_body),
+    footer = md(sprintf(
+      "<span style='color: %s;'>Report generated: %s (London)</span>",
+      dark_muted, london_time))
+  )
+  smtp_creds <- creds_envvar(
+    user        = gmail_user,
+    pass_envvar = "GMAIL_APP_PASSWORD",
+    host        = "smtp.gmail.com",
+    port        = 465,
+    use_ssl     = TRUE
+  )
+  tryCatch({
+    smtp_send(
+      email       = email,
+      to          = gmail_user,
+      from        = gmail_user,
+      subject     = sprintf("LLM Telemetry Report - %s", today),
+      credentials = smtp_creds
+    )
+    message("Email sent successfully (--send-only)!")
+  }, error = function(e) {
+    message("ERROR: Failed to send email via SMTP.")
+    message("Details: ", e$message)
+    cat("\n--- Email Body (--send-only, SMTP failed) ---\n")
+    cat(email_body)
+    cat("\n----------------------------------------------\n")
+    quit(status = 0)
+  })
+  quit(status = 0)
+}
 
 # Load cached ccusage data from inst/extdata/
 load_cached <- function(type) {
@@ -97,29 +167,9 @@ safe_date <- function(x) {
   tryCatch(as.Date(x), error = function(e) NA)
 }
 
-# Helper for formatting
-dollar <- function(x) {
-  if (is.null(x) || length(x) == 0) return("-")
-  if (is.na(x) || is.nan(x) || !is.finite(x)) return("-")
-  sprintf("$%.2f", x)
-}
-comma <- function(x) {
-  if (is.null(x) || length(x) == 0) return("-")
-  if (is.na(x) || is.nan(x) || !is.finite(x)) return("-")
-  format(x, big.mark = ",", scientific = FALSE)
-}
-millions <- function(x) {
-  if (is.null(x) || length(x) == 0) return("-")
-  if (is.na(x) || is.nan(x) || !is.finite(x)) return("-")
-  sprintf("%.1fM", x / 1e6)
-}
-# Guard for raw integer/count insertions that bypass dollar/comma/millions.
-# Prevents NaN or NA from reaching sprintf %s slots (cc_days, gm_days, etc).
-email_safe_num <- function(x, fallback = "-") {
-  if (is.null(x) || length(x) == 0) return(fallback)
-  if (is.na(x) || is.nan(x) || !is.finite(x)) return(fallback)
-  as.character(as.integer(x))
-}
+# Formatting helpers (dollar, comma, millions, email_safe_num) are sourced from
+# R/email_helpers.R above.  They are NOT redefined here — tests exercise the
+# real implementation by sourcing that same file.
 format_hhmm <- function(mins) {
   if (is.null(mins) || length(mins) == 0 || is.na(mins) || !is.finite(mins)) {
     return("-:-")

--- a/tests/testthat/test-email-nan-guard.R
+++ b/tests/testthat/test-email-nan-guard.R
@@ -3,41 +3,31 @@
 #
 # Coverage:
 #   - email_safe_num() renders NaN, NA, Inf, NULL, 0, and valid numbers correctly
-#   - The QA bash script's NaN check is case-sensitive (no false positives from
-#     substrings like "channel" containing "nan")
+#   - dollar(), comma(), millions() guard non-finite inputs
+#   - R-side QA check is case-sensitive (no false positives from substrings like
+#     "channel" or "nanum" containing "nan")
+#   - The qa_email_output.sh bash script uses case-sensitive NaN matching
+#     (grep without -i): "nan"-substring inputs do NOT trip the gate but a real
+#     "NaN" does
 #
-# Strategy: test the helper functions that wrap numeric insertions in the
-# send_daily_email.R script to ensure no unguarded NaN can reach sprintf.
-# These helpers are defined inline in the script; we redeclare them here to
-# keep tests self-contained (mirrors the approach in test-email-codex-section.R).
+# Strategy: source the production helpers from R/email_helpers.R so tests
+# exercise the REAL implementation.  A regression in email_helpers.R will now
+# cause these tests to fail (previously they would pass even with a broken
+# production file because helpers were redeclared locally).
 
-# ── Inline helpers (mirror send_daily_email.R) ────────────────────────────────
-dollar <- function(x) {
-  if (is.null(x) || length(x) == 0) return("-")
-  if (is.na(x) || is.nan(x) || !is.finite(x)) return("-")
-  sprintf("$%.2f", x)
+# ── Source production helpers ─────────────────────────────────────────────────
+# Locate R/email_helpers.R relative to the package root.
+# testthat runs with cwd = package root (via devtools::test()) or
+# tests/testthat/ (via Rscript).  We try both.
+.helpers_candidates <- c(
+  file.path(getwd(), "R", "email_helpers.R"),             # cwd = pkg root
+  file.path(getwd(), "..", "..", "R", "email_helpers.R")  # cwd = tests/testthat
+)
+.found <- Filter(file.exists, .helpers_candidates)
+if (length(.found) == 0L) {
+  stop("Could not locate R/email_helpers.R — tests cannot exercise production code")
 }
-comma <- function(x) {
-  if (is.null(x) || length(x) == 0) return("-")
-  if (is.na(x) || is.nan(x) || !is.finite(x)) return("-")
-  format(x, big.mark = ",", scientific = FALSE)
-}
-millions <- function(x) {
-  if (is.null(x) || length(x) == 0) return("-")
-  if (is.na(x) || is.nan(x) || !is.finite(x)) return("-")
-  sprintf("%.1fM", x / 1e6)
-}
-
-# email_safe_num() is the new guard for direct %s insertions (cc_days, gm_days,
-# cm_days, gm_sessions_count, n_sessions, cx_days, cx_sessions).
-# It must be defined in send_daily_email.R before we can reference it here.
-# For now define the spec here; the actual implementation must match.
-email_safe_num <- function(x, fallback = "-") {
-  if (is.null(x) || length(x) == 0) return(fallback)
-  if (is.na(x) || is.nan(x)) return(fallback)
-  if (!is.finite(x)) return(fallback)
-  as.character(as.integer(x))
-}
+source(.found[[1L]])
 
 # ── Tests: dollar() ───────────────────────────────────────────────────────────
 test_that("dollar() returns '-' for NaN", {
@@ -94,7 +84,7 @@ test_that("millions() returns '-' for NULL", {
   expect_equal(millions(NULL), "-")
 })
 
-# ── Tests: email_safe_num() — the new guard for raw integer insertions ────────
+# ── Tests: email_safe_num() — the guard for raw integer insertions ─────────
 test_that("email_safe_num() returns '-' for NaN (regression #137)", {
   expect_equal(email_safe_num(NaN), "-")
 })
@@ -133,7 +123,7 @@ test_that("email_safe_num() uses custom fallback", {
 })
 
 # ── Tests: NaN-in-HTML regression ────────────────────────────────────────────
-# Simulate the sprintf call for the gm_days field (line ~587 in send_daily_email.R)
+# Simulate the sprintf call for the gm_days field
 # BEFORE the fix: gm_days = NaN would produce "NaN" in HTML.
 # AFTER the fix:  email_safe_num(gm_days) produces "-".
 
@@ -159,10 +149,10 @@ test_that("gm_days = NA produces '-' with email_safe_num guard", {
 })
 
 # ── Tests: QA script false-positive (case-sensitivity) ───────────────────────
-# The bash QA script used grep -ci "NaN" (case-insensitive), which falsely
-# matched "nan" inside substrings like session IDs containing "nan" (e.g. a
-# Gemini session named "nanum-123", or any project/session name with "nan").
-# Verify that the R-side QA check is case-sensitive (uses fixed = TRUE).
+# The bash QA script previously used grep -ci "NaN" (case-insensitive), which
+# falsely matched "nan" inside substrings like session IDs containing "nan"
+# (e.g. "nanum-123", or any project/session name with "nan").
+# Verify the R-side QA check is case-sensitive (fixed = TRUE).
 
 test_that("R QA check does not flag 'nanum' session ID as NaN (case-sensitive)", {
   html <- "<td>nanum-session-abc123</td>"
@@ -189,4 +179,41 @@ test_that("bash -ci flag false-positives on 'nanum' session ID (documents the bu
   # Bash false-positives on "nan" in "nanum"; R does not
   expect_true(bash_match)   # demonstrates the bug: bash -ci fires on "nanum"
   expect_false(r_match)     # R fixed=TRUE correctly ignores "nanum"
+})
+
+# ── Integration fixture: qa_email_output.sh uses case-sensitive NaN check ─────
+# The script (inst/scripts/qa_email_output.sh) must NOT fire on lowercase "nan"
+# substrings but MUST fire on literal "NaN".
+# We verify the key grep lines from the script behave correctly without
+# executing bash (to keep tests portable and fast).
+
+test_that("qa_email_output.sh NaN grep: 'nanum' does not match (case-sensitive)", {
+  # The script uses: grep -c "NaN"  (no -i flag)
+  # Simulate in R: grepl without ignore.case
+  html_line <- "<td>nanum-session-abc123</td>"
+  # Case-sensitive grep -c "NaN" on this line returns 0 — no match
+  expect_false(grepl("NaN", html_line))
+})
+
+test_that("qa_email_output.sh NaN grep: literal 'NaN' matches (case-sensitive)", {
+  html_line <- "<td>NaN</td>"
+  # Case-sensitive grep -c "NaN" on this line returns 1 — match
+  expect_true(grepl("NaN", html_line))
+})
+
+test_that("qa_email_output.sh NaN grep: 'nan' (lowercase) does not match", {
+  html_line <- "<td>nan</td>"
+  # Case-sensitive grep -c "NaN" — "nan" != "NaN"
+  expect_false(grepl("NaN", html_line))
+})
+
+test_that("qa_email_output.sh skips HTML comment lines for NaN check", {
+  # The script pipes through: grep -v '<!--' | grep -c "NaN"
+  # So a line like <!-- QA:models_found=NaN --> is excluded
+  comment_line <- "<!-- QA:marker=NaN -->"
+  non_comment  <- "<td>NaN</td>"
+  # Comment lines are excluded by grep -v '<!--':
+  expect_true(grepl("<!--", comment_line))   # would be filtered out
+  expect_false(grepl("<!--", non_comment))   # this line IS checked for NaN
+  expect_true(grepl("NaN", non_comment))
 })

--- a/tests/testthat/test-email-nan-guard.R
+++ b/tests/testthat/test-email-nan-guard.R
@@ -217,3 +217,164 @@ test_that("qa_email_output.sh skips HTML comment lines for NaN check", {
   expect_false(grepl("<!--", non_comment))   # this line IS checked for NaN
   expect_true(grepl("NaN", non_comment))
 })
+
+# ── Source-assertion: qa_email_output.sh NaN grep must NOT use -i flag ────────
+# A regression back to `grep -ci "NaN"` (case-insensitive) would cause
+# false positives on session IDs or project names containing "nan".
+# This test reads the actual script and asserts the forbidden flag is absent
+# from the NaN check section.  A real regression in the script will fail this
+# test, even if all the R-simulation tests above still pass.
+#
+# Implementation note: the script passes patterns via a shell variable
+# (`grep -c "$pat"`) rather than quoting NaN inline.  We therefore inspect the
+# NaN-pattern loop header that declares `"NaN"` as one of the patterns, and the
+# grep command(s) within that loop, and assert that neither contains the -i flag.
+
+test_that("qa_email_output.sh NaN grep section does not use -i flag (source assertion)", {
+  # Locate the script relative to package root (same pattern as helper sourcing above)
+  script_candidates <- c(
+    file.path(getwd(), "inst", "scripts", "qa_email_output.sh"),           # cwd = pkg root
+    file.path(getwd(), "..", "..", "inst", "scripts", "qa_email_output.sh") # cwd = tests/testthat
+  )
+  script_path <- Filter(file.exists, script_candidates)
+  skip_if(length(script_path) == 0L, "qa_email_output.sh not found — skipping source assertion")
+  script_path <- script_path[[1L]]
+
+  script_lines <- readLines(script_path)
+
+  # Find the loop header line that declares "NaN" as one of the patterns.
+  # The script has: for pat in "NaN" ">NULL<" "NA_real_"; do
+  nan_loop_idx <- grep('"NaN"', script_lines)
+  expect_gt(length(nan_loop_idx), 0L,
+            label = 'At least one line containing "NaN" must exist in the script')
+
+  # The "NaN" declaration is in a for-loop header.  The grep call(s) that
+  # perform the actual NaN matching follow within the same loop body (within
+  # ~6 lines).  Look at the 8 lines after the first "NaN" occurrence and
+  # collect any lines that contain `grep` (the command, not the word in a
+  # comment).
+  window_start <- nan_loop_idx[[1L]]
+  window_end   <- min(window_start + 8L, length(script_lines))
+  window_lines <- script_lines[window_start:window_end]
+  # Match lines that contain a grep invocation (not just the word "grep" in a
+  # comment): look for lines where "grep" appears outside a leading "#"
+  non_comment <- window_lines[!grepl("^\\s*#", window_lines)]
+  nan_grep_lines <- grep("\\bgrep\\b", non_comment, value = TRUE)
+
+  expect_gt(length(nan_grep_lines), 0L,
+            label = "At least one grep call must appear in the NaN pattern loop body")
+
+  # None of the grep calls in this section should carry the -i flag.
+  # Flag variants that indicate case-insensitive matching:
+  #   -i, -ci, -ic, -Ei, -iE, -cia, grep -i, grep -ci "NaN", etc.
+  # We check: does any grep invocation on the line have a flag cluster that
+  # includes the letter "i"?
+  # Pattern: `grep` followed by optional content then `-` then a flag string
+  # that contains "i" before any space or quote.
+  has_case_insensitive <- grepl("\\bgrep\\b[^|\\n]*\\s-[a-zA-Z]*i[a-zA-Z]*", nan_grep_lines)
+  expect_false(any(has_case_insensitive),
+               label = paste(
+                 "grep call(s) in the NaN check section of qa_email_output.sh",
+                 "must NOT use the -i (case-insensitive) flag.",
+                 "Offending line(s):", paste(nan_grep_lines[has_case_insensitive], collapse = "; ")
+               ))
+})
+
+# ── Functional: run actual qa_email_output.sh against tiny fixture files ──────
+# These tests run the real bash script so a script regression (e.g. reverting
+# to grep -ci) is caught by an actual non-zero exit code, not just source text.
+# The fixtures include the required structural features the script checks for.
+
+test_that("qa_email_output.sh exits 0 for valid HTML with 'nanum' (no false positive)", {
+  skip_if(.Platform$OS.type != "unix", "bash tests require a Unix shell")
+  script_candidates <- c(
+    file.path(getwd(), "inst", "scripts", "qa_email_output.sh"),
+    file.path(getwd(), "..", "..", "inst", "scripts", "qa_email_output.sh")
+  )
+  script_path <- Filter(file.exists, script_candidates)
+  skip_if(length(script_path) == 0L, "qa_email_output.sh not found")
+  script_path <- script_path[[1L]]
+
+  # Minimal valid HTML that satisfies ALL checks in the script:
+  #   Required features: "Summary" (as >Summary<), "font-weight: bold",
+  #                      dashboard URL, at least one $N.NN cost
+  #   Ordering: "Time Block Activity" before ">Summary<"
+  #   QA markers: blocks_grouped_by_day, model_breakdown_days, models_found
+  # "nanum-session-abc123" must NOT trigger the NaN gate (false-positive check).
+  # NOTE: the ordering check uses `grep -n ">Summary<"` (angle brackets), so we
+  # must render as ">Summary<" not just "Summary".
+  fixture <- tempfile(fileext = ".html")
+  on.exit(unlink(fixture), add = TRUE)
+  # Helper: build a minimal but structurally complete HTML fixture.
+  # The script uses `grep -n ">Summary<"` (angle brackets) for the ordering
+  # check, so the fixture must contain that literal string.  It also uses
+  # `grep -qi` for optional features ("Time Block Activity", "Daily Cost by
+  # Model", "MTok", "blocks)") and `grep -qE '\$[0-9]+\.[0-9]{2}'` for costs.
+  # Including all of them avoids false WARNs and prevents set -euo pipefail
+  # crashes from grep returning 1 on missing patterns.
+  writeLines(c(
+    "<html><body>",
+    "<style>.hdr { font-weight: bold; }</style>",
+    "<h2>Time Block Activity (3 blocks)</h2>",
+    "<h2>Daily Cost by Model</h2>",
+    "<td>MTok used</td>",
+    "<td>>Summary< section</td>",   # provides the literal ">Summary<" token
+    "Summary",                       # satisfies grep -qi Summary
+    "<a href='https://johngavin.github.io/llmtelemetry'>Dashboard</a>",
+    "<td>$1.23</td>",
+    "<td>nanum-session-abc123</td>",
+    "<!-- QA:blocks_grouped_by_day=3 -->",
+    "<!-- QA:model_breakdown_days=3 -->",
+    "<!-- QA:models_found=claude-sonnet-4-6 -->"
+  ), fixture)
+
+  result <- system2("bash", args = c(script_path, fixture),
+                    stdout = TRUE, stderr = TRUE)
+  exit_code <- attr(result, "status")
+  # system2 returns NULL status on success (exit 0)
+  expect_true(is.null(exit_code) || exit_code == 0L,
+              label = paste(
+                "Script should exit 0 for HTML containing 'nanum' (not NaN).",
+                "Output:", paste(result, collapse = "\n")
+              ))
+})
+
+test_that("qa_email_output.sh exits 1 for HTML containing literal 'NaN'", {
+  skip_if(.Platform$OS.type != "unix", "bash tests require a Unix shell")
+  script_candidates <- c(
+    file.path(getwd(), "inst", "scripts", "qa_email_output.sh"),
+    file.path(getwd(), "..", "..", "inst", "scripts", "qa_email_output.sh")
+  )
+  script_path <- Filter(file.exists, script_candidates)
+  skip_if(length(script_path) == 0L, "qa_email_output.sh not found")
+  script_path <- script_path[[1L]]
+
+  # Same structural HTML but with a literal "NaN" in a visible table cell.
+  # The NaN gate must detect this and exit 1.
+  fixture <- tempfile(fileext = ".html")
+  on.exit(unlink(fixture), add = TRUE)
+  writeLines(c(
+    "<html><body>",
+    "<style>.hdr { font-weight: bold; }</style>",
+    "<h2>Time Block Activity (3 blocks)</h2>",
+    "<h2>Daily Cost by Model</h2>",
+    "<td>MTok used</td>",
+    "<td>>Summary< section</td>",
+    "Summary",
+    "<a href='https://johngavin.github.io/llmtelemetry'>Dashboard</a>",
+    "<td>$1.23</td>",
+    "<td>NaN</td>",   # literal NaN — must trip the NaN gate
+    "<!-- QA:blocks_grouped_by_day=3 -->",
+    "<!-- QA:model_breakdown_days=3 -->",
+    "<!-- QA:models_found=claude-sonnet-4-6 -->"
+  ), fixture)
+
+  result <- system2("bash", args = c(script_path, fixture),
+                    stdout = TRUE, stderr = TRUE)
+  exit_code <- attr(result, "status")
+  expect_equal(exit_code, 1L,
+               label = paste(
+                 "Script should exit 1 when HTML contains literal 'NaN'.",
+                 "Output:", paste(result, collapse = "\n")
+               ))
+})

--- a/tests/testthat/test-email-nan-guard.R
+++ b/tests/testthat/test-email-nan-guard.R
@@ -1,0 +1,192 @@
+# test-email-nan-guard.R
+# Tests for issue #137: NaN guard in email formatting helpers
+#
+# Coverage:
+#   - email_safe_num() renders NaN, NA, Inf, NULL, 0, and valid numbers correctly
+#   - The QA bash script's NaN check is case-sensitive (no false positives from
+#     substrings like "channel" containing "nan")
+#
+# Strategy: test the helper functions that wrap numeric insertions in the
+# send_daily_email.R script to ensure no unguarded NaN can reach sprintf.
+# These helpers are defined inline in the script; we redeclare them here to
+# keep tests self-contained (mirrors the approach in test-email-codex-section.R).
+
+# ── Inline helpers (mirror send_daily_email.R) ────────────────────────────────
+dollar <- function(x) {
+  if (is.null(x) || length(x) == 0) return("-")
+  if (is.na(x) || is.nan(x) || !is.finite(x)) return("-")
+  sprintf("$%.2f", x)
+}
+comma <- function(x) {
+  if (is.null(x) || length(x) == 0) return("-")
+  if (is.na(x) || is.nan(x) || !is.finite(x)) return("-")
+  format(x, big.mark = ",", scientific = FALSE)
+}
+millions <- function(x) {
+  if (is.null(x) || length(x) == 0) return("-")
+  if (is.na(x) || is.nan(x) || !is.finite(x)) return("-")
+  sprintf("%.1fM", x / 1e6)
+}
+
+# email_safe_num() is the new guard for direct %s insertions (cc_days, gm_days,
+# cm_days, gm_sessions_count, n_sessions, cx_days, cx_sessions).
+# It must be defined in send_daily_email.R before we can reference it here.
+# For now define the spec here; the actual implementation must match.
+email_safe_num <- function(x, fallback = "-") {
+  if (is.null(x) || length(x) == 0) return(fallback)
+  if (is.na(x) || is.nan(x)) return(fallback)
+  if (!is.finite(x)) return(fallback)
+  as.character(as.integer(x))
+}
+
+# ── Tests: dollar() ───────────────────────────────────────────────────────────
+test_that("dollar() returns '-' for NaN", {
+  expect_equal(dollar(NaN), "-")
+})
+
+test_that("dollar() returns '-' for NA", {
+  expect_equal(dollar(NA), "-")
+})
+
+test_that("dollar() returns '-' for NULL", {
+  expect_equal(dollar(NULL), "-")
+})
+
+test_that("dollar() returns '-' for Inf", {
+  expect_equal(dollar(Inf), "-")
+})
+
+test_that("dollar() formats zero correctly", {
+  expect_equal(dollar(0), "$0.00")
+})
+
+test_that("dollar() formats positive value correctly", {
+  expect_equal(dollar(1.5), "$1.50")
+})
+
+# ── Tests: comma() ────────────────────────────────────────────────────────────
+test_that("comma() returns '-' for NaN", {
+  expect_equal(comma(NaN), "-")
+})
+
+test_that("comma() returns '-' for NA", {
+  expect_equal(comma(NA), "-")
+})
+
+test_that("comma() returns '-' for NULL", {
+  expect_equal(comma(NULL), "-")
+})
+
+test_that("comma() formats zero", {
+  expect_equal(comma(0), "0")
+})
+
+# ── Tests: millions() ─────────────────────────────────────────────────────────
+test_that("millions() returns '-' for NaN", {
+  expect_equal(millions(NaN), "-")
+})
+
+test_that("millions() returns '-' for NA", {
+  expect_equal(millions(NA), "-")
+})
+
+test_that("millions() returns '-' for NULL", {
+  expect_equal(millions(NULL), "-")
+})
+
+# ── Tests: email_safe_num() — the new guard for raw integer insertions ────────
+test_that("email_safe_num() returns '-' for NaN (regression #137)", {
+  expect_equal(email_safe_num(NaN), "-")
+})
+
+test_that("email_safe_num() returns '-' for NA", {
+  expect_equal(email_safe_num(NA), "-")
+})
+
+test_that("email_safe_num() returns '-' for Inf", {
+  expect_equal(email_safe_num(Inf), "-")
+})
+
+test_that("email_safe_num() returns '-' for NULL", {
+  expect_equal(email_safe_num(NULL), "-")
+})
+
+test_that("email_safe_num() returns '-' for empty vector", {
+  expect_equal(email_safe_num(numeric(0)), "-")
+})
+
+test_that("email_safe_num() returns '0' for zero", {
+  expect_equal(email_safe_num(0), "0")
+})
+
+test_that("email_safe_num() returns '5' for 5", {
+  expect_equal(email_safe_num(5), "5")
+})
+
+test_that("email_safe_num() returns '5' for 5.9 (truncates to int)", {
+  expect_equal(email_safe_num(5.9), "5")
+})
+
+test_that("email_safe_num() uses custom fallback", {
+  expect_equal(email_safe_num(NaN, fallback = "n/a"), "n/a")
+  expect_equal(email_safe_num(NA, fallback = "0"), "0")
+})
+
+# ── Tests: NaN-in-HTML regression ────────────────────────────────────────────
+# Simulate the sprintf call for the gm_days field (line ~587 in send_daily_email.R)
+# BEFORE the fix: gm_days = NaN would produce "NaN" in HTML.
+# AFTER the fix:  email_safe_num(gm_days) produces "-".
+
+test_that("gm_days = NaN produces 'NaN' without guard (demonstrates the bug)", {
+  gm_days <- NaN
+  # Simulate what the old code does: passes gm_days directly to sprintf
+  html_fragment <- sprintf("<td>%s</td>", gm_days)
+  expect_match(html_fragment, "NaN")
+})
+
+test_that("gm_days = NaN produces '-' with email_safe_num guard (demonstrates the fix)", {
+  gm_days <- NaN
+  html_fragment <- sprintf("<td>%s</td>", email_safe_num(gm_days))
+  expect_false(grepl("NaN", html_fragment, fixed = TRUE))
+  expect_match(html_fragment, "-")
+})
+
+test_that("gm_days = NA produces '-' with email_safe_num guard", {
+  gm_days <- NA
+  html_fragment <- sprintf("<td>%s</td>", email_safe_num(gm_days))
+  expect_false(grepl("NaN", html_fragment, fixed = TRUE))
+  expect_match(html_fragment, "-")
+})
+
+# ── Tests: QA script false-positive (case-sensitivity) ───────────────────────
+# The bash QA script used grep -ci "NaN" (case-insensitive), which falsely
+# matched "nan" inside substrings like session IDs containing "nan" (e.g. a
+# Gemini session named "nanum-123", or any project/session name with "nan").
+# Verify that the R-side QA check is case-sensitive (uses fixed = TRUE).
+
+test_that("R QA check does not flag 'nanum' session ID as NaN (case-sensitive)", {
+  html <- "<td>nanum-session-abc123</td>"
+  # R-side check with fixed = TRUE (correct): "nan" != "NaN"
+  expect_false(grepl("NaN", html, fixed = TRUE))
+})
+
+test_that("R QA check does not flag 'finance' project as NaN (case-sensitive)", {
+  html <- "<td>finance-tracker</td>"
+  expect_false(grepl("NaN", html, fixed = TRUE))
+})
+
+test_that("R QA check catches actual 'NaN' correctly", {
+  html <- sprintf("<td>%s</td>", NaN)  # produces "<td>NaN</td>"
+  expect_true(grepl("NaN", html, fixed = TRUE))
+})
+
+test_that("bash -ci flag false-positives on 'nanum' session ID (documents the bug)", {
+  # This test documents WHY grep -ci is wrong.
+  # We simulate grep -ci behaviour with ignore.case = TRUE in R.
+  html <- "<td>nanum-session-abc123</td>"
+  bash_match <- grepl("NaN", html, ignore.case = TRUE)  # simulates grep -ci
+  r_match    <- grepl("NaN", html, fixed = TRUE)          # correct R check
+  # Bash false-positives on "nan" in "nanum"; R does not
+  expect_true(bash_match)   # demonstrates the bug: bash -ci fires on "nanum"
+  expect_false(r_match)     # R fixed=TRUE correctly ignores "nanum"
+})


### PR DESCRIPTION
## Summary

Fixes two distinct problems from issue #137:

- **P1 (NaN false positive):** `qa_email_output.sh` used `grep -ci` (case-insensitive) for the `NaN` check, causing false positives from any session ID or project name containing the substring `nan` (e.g. a Gemini session named `nanum-...`). The R-side inline QA correctly used `fixed=TRUE` (case-sensitive) and passed while the bash check failed, triggering a spurious workflow failure and a second email to the user. Fix: remove `-i` from `grep -c` call in `qa_email_output.sh`.
- **P1 (defensive hardening):** Add `email_safe_num()` helper and wrap all raw numeric insertions in `sprintf` (`cc_days`, `gm_days`, `cm_days`, `gm_sessions_count`, `n_sessions`, `cx_days`, `cx_sessions`) that previously bypassed `dollar`/`comma`/`millions`. Also extend those three helpers to guard against `Inf`/`-Inf`.
- **P2 (gate ordering):** Add `--build-only` flag to `send_daily_email.R`. Restructure the workflow: **build → validate → send**. The bash QA step now runs without `if: always()`, so a QA failure halts the workflow before the SMTP send step runs.

## Test plan

- [x] New `tests/testthat/test-email-nan-guard.R` with 33 tests — passes GREEN
- [x] Full test suite: 795 PASS, 0 FAIL, 1 SKIP (unrelated pre-existing skip)
- [x] `bash -n inst/scripts/qa_email_output.sh` — no syntax errors
- [x] YAML step order verified: Build email HTML → Validate email output → Send Report
- [x] `grep -c "NaN"` (case-sensitive) no longer matches `nanum` substrings
- [x] `email_safe_num(NaN)` returns `"-"`, `email_safe_num(NA)` returns `"-"`, `email_safe_num(5)` returns `"5"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)