### PR TITLE
fix(#156): escape quotes in embedded JS/CSS so Shinylive app.R parses

### DIFF
--- a/vignettes/dashboard_shinylive.qmd
+++ b/vignettes/dashboard_shinylive.qmd
@@ -579,6 +579,7 @@ ui <- page_navbar(
     # Phase 2B: DuckDB-WASM — initialise once, expose queryAndRenderSessions() globally.
     # Type module gives us top-level await; the Shiny message handler is registered
     # after shiny:connected fires so the message bus is ready.
+    # Embedded JS — literal quotes MUST be escaped (single-quoted R string): use \' for each JS '
     tags$script(type = "module", HTML('
       const PARQUET_URL = new URL("data/v1/sessions.parquet", window.location.href).href;
       const duckdb = await import("https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.32.0/+esm");
@@ -601,7 +602,7 @@ ui <- page_navbar(
 
       window.queryAndRenderSessions = async function(projects, min_date) {
         // "__NONE__" sentinel: user selected "None" — render empty chart without DuckDB query.
-        // Apostrophes in project names are escaped by doubling: p.replace(/'/g, "''")
+        // Apostrophes in project names are escaped by doubling: p.replace(/\'/g, "\'\'")
         if (projects === "__NONE__") {
           const el = document.getElementById("proj_sessions_ec");
           if (!el) return;
@@ -616,7 +617,7 @@ ui <- page_navbar(
         // or a non-empty Array (specific project selection).
         const filters = ["canonical_project IS NOT NULL"];
         if (Array.isArray(projects) && projects.length > 0)
-          filters.push("canonical_project IN (" + projects.map(p => "'" + p.replace(/'/g, "''") + "'").join(",") + ")");
+          filters.push("canonical_project IN (" + projects.map(p => "\'" + p.replace(/\'/g, "\'\'") + "\'").join(",") + ")");
         if (min_date) filters.push("started_at >= \'" + min_date + "\'");
         const r = await conn.query(
           "SELECT canonical_project, COUNT(*)::INTEGER AS n " +


### PR DESCRIPTION
## Summary

- The `tags$script(type="module", HTML('...'))` block in `vignettes/dashboard_shinylive.qmd` used a single-quoted R string as the HTML argument
- Literal `'` characters in the embedded JavaScript (regex `/'/g` and SQL-quoting logic `"'" + p.replace(/'/g, "''") + "'"`) terminated the R string prematurely
- The Shinylive extension copies the chunk verbatim into `app.R`; the browser's R parser aborted sourcing, taking the dashboard down

## Changes

Two lines in the `tags$script(type = "module", HTML('...'))` block:
1. Comment (line ~605): `/'/g, "\''"` → `/\'/g, "\'\'"` — illustrative regex comment now uses escaped quotes
2. SQL-quoting filter (line ~620): `"'" + p.replace(/'/g, "''") + "'"` → `"\'" + p.replace(/\'/g, "\'\'") + "\'"`
3. Added clarifying comment above the block: `# Embedded JS — literal quotes MUST be escaped (single-quoted R string): use \' for each JS '`

Delivered browser bytes are identical — R's `\'` escape resolves to `'` at runtime.

## Verification

- Extracted chunk body to `/tmp/app_check.R` and ran `parse("/tmp/app_check.R")` in the project nix shell
- Result: `PARSE OK` with zero errors
- Only one `HTML('...')` single-quoted block exists in the file (confirmed via `grep -n "HTML('"`)
- The two double-quoted blocks (`tags$style(HTML("..."))` and `tags$script(HTML("..."))`) contain only single quotes inside, which are safe in a double-quoted R string — no changes needed there

## Test plan

- [ ] CI renders `vignettes/dashboard_shinylive.qmd` without error
- [ ] Deployed Shinylive dashboard loads in browser without parse abort
- [ ] DuckDB session query (project filter with apostrophes in project names) works correctly — SQL quoting logic unchanged in delivered bytes

🤖 Generated with [Claude Code](https://claude.com/claude-code)