### PR TITLE
fix: dashboard data 404 — use origin-absolute base_url for WebR fetches

### DIFF
--- a/vignettes/dashboard_shinylive.qmd
+++ b/vignettes/dashboard_shinylive.qmd
@@ -301,12 +301,15 @@ pal <- list(
 )
 
 # --- Data loading -------------------------------------------------------------
-# base_url is a relative prefix so fetches work from any host+path.
-# "/data/X.json" would be an absolute path — on the GH Pages project site at
-# https://johngavin.github.io/llmtelemetry/ it resolves to the wrong host
-# root. Using "data/" as a relative prefix resolves correctly from wherever
-# the HTML is served (local http.server or gh-pages sub-path).
-base_url <- "data/"
+# WebR's download.file runs in a Web Worker; relative URLs (e.g. "data/X.json")
+# resolve against the worker's deep script path, NOT the page URL — so they
+# 404 in production. Plain "/data/" is also wrong: it resolves to the host
+# root, dropping the "/llmtelemetry/" project sub-path on the GH Pages site.
+# The correct value is the origin-absolute project path "/llmtelemetry/data/"
+# which resolves to https://johngavin.github.io/llmtelemetry/data/X.json.
+# NOTE: if this dashboard is ever served from a different base path, this
+# prefix must be updated (or computed from window.location.pathname).
+base_url <- "/llmtelemetry/data/"
 
 load_json <- function(filename) {
   tryCatch({


### PR DESCRIPTION
## Summary

- **Root cause:** `base_url <- "data/"` (relative path) used for WebR `download.file` calls inside the Shinylive dashboard. WebR's `download.file` runs in a Web Worker; relative URLs resolve against the worker's deep script path (e.g. `/_framework/...`), not the page URL. Every `data/X.json` fetch returned HTTP 404, `tryCatch` silently returned `NULL`, and all cards/plots showed no data.
- **Fix:** Changed `base_url` to `"/llmtelemetry/data/"` — the origin-absolute project sub-path that resolves correctly to `https://johngavin.github.io/llmtelemetry/data/X.json` on the GH Pages project site regardless of the Web Worker's script location.
- **Comment updated:** Old comment incorrectly stated that `"data/"` "resolves correctly from wherever the HTML is served." Replaced with an accurate explanation of the WebR worker context, why plain `/data/` is also wrong (drops the `/llmtelemetry/` sub-path), and a note that the prefix must be updated if the dashboard base path ever changes.
- **JS DuckDB-WASM `PARQUET_URL` not changed:** already uses `new URL('data/v1/sessions.parquet', window.location.href)` which anchors against the page URL and resolves correctly.

## Test plan

- [x] Exactly one `base_url <-` assignment remains in the file, set to `"/llmtelemetry/data/"`
- [x] `parse()` of the extracted `{shinylive-r}` chunk body passes clean (111 expressions, no errors) — satisfies the #156 gate
- [x] Branch does not touch `origin/main` directly; PR targets `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)