### PR TITLE
fix: embedded-JS syntax error in dashboard Shinylive app

### DIFF
--- a/vignettes/dashboard_shinylive.qmd
+++ b/vignettes/dashboard_shinylive.qmd
@@ -589,7 +589,7 @@ ui <- page_navbar(
       const bundle = await duckdb.selectBundle(duckdb.getJsDelivrBundles());
       const worker = new Worker(
         URL.createObjectURL(new Blob(
-          ["importScripts(\"" + bundle.mainWorker + "\");"],
+          ["importScripts(\\"" + bundle.mainWorker + "\\");"],
           {type:"text/javascript"}
         ))
       );


### PR DESCRIPTION
## Summary

- **Root cause:** `\"` inside the single-quoted R string `HTML('...')` was being parsed by R's string evaluator as just `"` (backslash consumed as an escape prefix), stripping the backslash from the delivered JavaScript. This produced adjacent string literals `\"importScripts(\"\"` in the browser, causing `Uncaught SyntaxError: Unexpected string` at `app_<id>/:98`.
- **Fix:** Changed `\"` to `\\"` (two backslashes + doublequote) at the one affected location — the `importScripts` Blob content in the DuckDB-WASM Worker constructor. After R parsing, `\\` → `\` and `"` → `"`, so the browser receives the correct `\"` JS escape sequence.
- **Scope:** Single-character change (1 backslash added in 2 places on 1 line) in `vignettes/dashboard_shinylive.qmd:592`. No R logic changed.

## Root cause in detail

```r
# Single-quoted R string — R escape rules:
# \"  → "   (backslash consumed, bare doublequote delivered)
# \\" → \"  (two backslashes → one, plus literal doublequote = backslash+doublequote)

# BEFORE (broken: \"\" = adjacent string literals in JS)
tags$script(type = "module", HTML('
  ...
  ["importScripts(\"" + bundle.mainWorker + "\");"],
  ...
'))

# AFTER (correct: \"\" = JS-escaped doublequote, closes string, then concatenation)
tags$script(type = "module", HTML('
  ...
  ["importScripts(\\"" + bundle.mainWorker + "\\");"],
  ...
'))
```

## Test plan

- [x] `node --check` on the simulated delivered JS: PASS
- [x] `parse()` on the full `{shinylive-r}` chunk: 111 expressions, PASS
- [x] `testthat::test_file("test-dashboard-filter-sentinels.R")`: 13/13 PASS
- [ ] Deploy to staging / observe browser console: `SyntaxError` at `app_<id>/:98` should be gone
- [ ] Verify DuckDB-WASM "Sessions by Project" panel renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)