### PR TITLE
fix(test): harden validation/test robustness (#154 #155 #168)

### DIFF
--- a/inst/scripts/export_dashboard_data.R
+++ b/inst/scripts/export_dashboard_data.R
@@ -1870,8 +1870,11 @@ for (f in optional_schema_files) {
     }
   )
   # Must be a JSON array: an unnamed (plain) list. Named lists are JSON objects;
-  # scalars are not lists at all. Both must be rejected (#141 round-3).
-  if (!is.list(parsed) || length(names(parsed)) > 0L) {
+  # scalars are not lists at all. Both must be rejected (#141 round-3, #154).
+  # Use !is.null(names(parsed)) rather than length(names(parsed)) > 0L:
+  # jsonlite parses {} as a named list with names = character(0) (length 0 but
+  # NOT NULL), so the length-based guard incorrectly accepts {} as a valid array.
+  if (!is.list(parsed) || !is.null(names(parsed))) {
     stop(sprintf(
       "QA FAILED: %s.json must be a JSON array but got %s",
       f, if (!is.list(parsed)) class(parsed)[1L] else "JSON object (named list)"

--- a/tests/testthat/test-email-nan-guard.R
+++ b/tests/testthat/test-email-nan-guard.R
@@ -231,12 +231,14 @@ test_that("qa_email_output.sh skips HTML comment lines for NaN check", {
 # grep command(s) within that loop, and assert that neither contains the -i flag.
 
 test_that("qa_email_output.sh NaN grep section does not use -i flag (source assertion)", {
-  # Locate the script relative to package root (same pattern as helper sourcing above)
+  # Locate the script: system.file() is primary (works in installed/CHECK contexts);
+  # getwd()-relative paths are fallbacks for devtools::test() (#155).
   script_candidates <- c(
-    file.path(getwd(), "inst", "scripts", "qa_email_output.sh"),           # cwd = pkg root
-    file.path(getwd(), "..", "..", "inst", "scripts", "qa_email_output.sh") # cwd = tests/testthat
+    system.file("scripts", "qa_email_output.sh", package = "llmtelemetry"), # primary: installed
+    file.path(getwd(), "inst", "scripts", "qa_email_output.sh"),             # cwd = pkg root
+    file.path(getwd(), "..", "..", "inst", "scripts", "qa_email_output.sh")  # cwd = tests/testthat
   )
-  script_path <- Filter(file.exists, script_candidates)
+  script_path <- Filter(nzchar, Filter(file.exists, script_candidates))
   skip_if(length(script_path) == 0L, "qa_email_output.sh not found — skipping source assertion")
   script_path <- script_path[[1L]]
 
@@ -288,10 +290,11 @@ test_that("qa_email_output.sh NaN grep section does not use -i flag (source asse
 test_that("qa_email_output.sh exits 0 for valid HTML with 'nanum' (no false positive)", {
   skip_if(.Platform$OS.type != "unix", "bash tests require a Unix shell")
   script_candidates <- c(
+    system.file("scripts", "qa_email_output.sh", package = "llmtelemetry"), # primary: installed
     file.path(getwd(), "inst", "scripts", "qa_email_output.sh"),
     file.path(getwd(), "..", "..", "inst", "scripts", "qa_email_output.sh")
   )
-  script_path <- Filter(file.exists, script_candidates)
+  script_path <- Filter(nzchar, Filter(file.exists, script_candidates))
   skip_if(length(script_path) == 0L, "qa_email_output.sh not found")
   script_path <- script_path[[1L]]
 
@@ -342,10 +345,11 @@ test_that("qa_email_output.sh exits 0 for valid HTML with 'nanum' (no false posi
 test_that("qa_email_output.sh exits 1 for HTML containing literal 'NaN'", {
   skip_if(.Platform$OS.type != "unix", "bash tests require a Unix shell")
   script_candidates <- c(
+    system.file("scripts", "qa_email_output.sh", package = "llmtelemetry"), # primary: installed
     file.path(getwd(), "inst", "scripts", "qa_email_output.sh"),
     file.path(getwd(), "..", "..", "inst", "scripts", "qa_email_output.sh")
   )
-  script_path <- Filter(file.exists, script_candidates)
+  script_path <- Filter(nzchar, Filter(file.exists, script_candidates))
   skip_if(length(script_path) == 0L, "qa_email_output.sh not found")
   script_path <- script_path[[1L]]
 
@@ -369,8 +373,12 @@ test_that("qa_email_output.sh exits 1 for HTML containing literal 'NaN'", {
     "<!-- QA:models_found=claude-sonnet-4-6 -->"
   ), fixture)
 
-  result <- system2("bash", args = c(script_path, fixture),
-                    stdout = TRUE, stderr = TRUE)
+  # suppressWarnings: system2() emits a warning when the process exits non-zero
+  # while stdout/stderr are captured; we expect exit 1, so silence the warning.
+  result <- suppressWarnings(
+    system2("bash", args = c(script_path, fixture),
+            stdout = TRUE, stderr = TRUE)
+  )
   exit_code <- attr(result, "status")
   expect_equal(exit_code, 1L,
                label = paste(

--- a/tests/testthat/test-export-dashboard-data.R
+++ b/tests/testthat/test-export-dashboard-data.R
@@ -491,17 +491,24 @@ test_that("export_dashboard_data.R CI fallback always writes ccusage_blocks.json
     )
   )
 
-  # (3) The fallback must contain a write_json call (the empty-array path).
-  #     PR #163 uses intermediate variables (fallback_blocks_dst) rather than
-  #     literal path strings in write_json calls — search for write_json near
-  #     fallback_blocks_dst rather than for the literal filename.
-  has_write_json_fallback <- any(grepl("write_json", fallback_lines)) &&
-    any(grepl("fallback_blocks_dst|ccusage_blocks", fallback_lines))
+  # (3) The fallback must contain a write_json call in the blocks-specific branch.
+  #     PR #163 uses intermediate variables (fallback_blocks_dst). We narrow the
+  #     check to the ~15-line window around `fallback_blocks_src <-` to avoid
+  #     unrelated write_json calls elsewhere in the script satisfying the assertion
+  #     (#168: the broad fallback_lines-to-EOF search was too loose).
+  blocks_src_idx <- grep("fallback_blocks_src\\s*<-", lines)
+  skip_if(length(blocks_src_idx) == 0L,
+          "fallback_blocks_src assignment not found in export_dashboard_data.R")
+  blocks_window_start <- blocks_src_idx[[1L]]
+  blocks_window_end   <- min(length(lines), blocks_window_start + 15L)
+  blocks_branch_lines <- lines[blocks_window_start:blocks_window_end]
+  has_write_json_fallback <- any(grepl("write_json", blocks_branch_lines)) &&
+    any(grepl("fallback_blocks_dst", blocks_branch_lines))
   expect_true(
     has_write_json_fallback,
     info = paste(
-      "CI fallback does not contain a write_json call for ccusage_blocks.json.",
-      "Add write_json(list(), fallback_blocks_dst, auto_unbox=TRUE) in the else branch. Fixes #141."
+      "CI fallback blocks branch does not contain a write_json call for ccusage_blocks.json.",
+      "Add write_json(list(), fallback_blocks_dst, auto_unbox=TRUE) in the else branch. Fixes #141 #168."
     )
   )
 })
@@ -586,3 +593,37 @@ test_that("export_dashboard_data.R schema-only validation rejects non-array ccus
     )
   )
 })
+
+test_that("optional schema guard: [] passes, {} and scalar are REJECTED (#154)", {
+  # Behavioural test for the !is.null(names(parsed)) guard (#154).
+  # jsonlite::fromJSON("{}") returns a named list with names = character(0)
+  # (length 0 but NOT NULL), so the old `length(names(parsed)) > 0L` guard
+  # incorrectly accepted {}.  The fix uses !is.null(names(parsed)).
+  #
+  # Acceptance criteria (directly mirror what export_dashboard_data.R does):
+  #   [] -> is.list = TRUE, is.null(names) = TRUE  -> PASS
+  #   {} -> is.list = TRUE, is.null(names) = FALSE -> FAIL
+  #   42 -> is.list = FALSE                        -> FAIL
+  is_valid_array <- function(json_str) {
+    parsed <- jsonlite::fromJSON(json_str, simplifyVector = FALSE,
+                                 simplifyDataFrame = FALSE, simplifyMatrix = FALSE)
+    is.list(parsed) && is.null(names(parsed))
+  }
+
+  # Empty array [] must pass
+  expect_true(is_valid_array("[]"),
+              label = "[] (empty JSON array) must be accepted as a valid array")
+
+  # Populated array must pass
+  expect_true(is_valid_array('[{"a":1},{"a":2}]'),
+              label = "Populated JSON array must be accepted")
+
+  # Empty object {} must be REJECTED (#154 — the bug: old guard allowed {})
+  expect_false(is_valid_array("{}"),
+               label = "{} (empty JSON object) must be REJECTED, not accepted as an array")
+
+  # Scalar must be REJECTED
+  expect_false(is_valid_array("42"),
+               label = "Scalar JSON value must be REJECTED, not accepted as an array")
+})
+

--- a/tests/testthat/test-export-dashboard-data.R
+++ b/tests/testthat/test-export-dashboard-data.R
@@ -491,23 +491,35 @@ test_that("export_dashboard_data.R CI fallback always writes ccusage_blocks.json
     )
   )
 
-  # (3) The fallback must contain a write_json call in the blocks-specific branch.
+  # (3) The fallback must contain a write_json call whose PATH argument is
+  #     fallback_blocks_dst, not merely any write_json anywhere in the window.
   #     PR #163 uses intermediate variables (fallback_blocks_dst). We narrow the
   #     check to the ~15-line window around `fallback_blocks_src <-` to avoid
   #     unrelated write_json calls elsewhere in the script satisfying the assertion
   #     (#168: the broad fallback_lines-to-EOF search was too loose).
+  #     Round-2 tightening: collapse the window to a single string and require
+  #     write_json(<first-arg>, fallback_blocks_dst, ...) — i.e. fallback_blocks_dst
+  #     must appear as the SECOND positional argument (the path), not as an
+  #     unrelated token on a separate line.
   blocks_src_idx <- grep("fallback_blocks_src\\s*<-", lines)
   skip_if(length(blocks_src_idx) == 0L,
           "fallback_blocks_src assignment not found in export_dashboard_data.R")
   blocks_window_start <- blocks_src_idx[[1L]]
   blocks_window_end   <- min(length(lines), blocks_window_start + 15L)
   blocks_branch_lines <- lines[blocks_window_start:blocks_window_end]
-  has_write_json_fallback <- any(grepl("write_json", blocks_branch_lines)) &&
-    any(grepl("fallback_blocks_dst", blocks_branch_lines))
+  # Collapse to a single string so multi-line calls are matched as one unit.
+  blocks_window_text  <- paste(blocks_branch_lines, collapse = "\n")
+  # Match write_json(<any-first-arg>, fallback_blocks_dst, ...) — the destination
+  # must be fallback_blocks_dst, not just any co-occurring token.
+  has_write_json_fallback <- grepl(
+    "write_json\\s*\\([^,]+,\\s*fallback_blocks_dst",
+    blocks_window_text
+  )
   expect_true(
     has_write_json_fallback,
     info = paste(
-      "CI fallback blocks branch does not contain a write_json call for ccusage_blocks.json.",
+      "CI fallback blocks branch does not contain write_json(<data>, fallback_blocks_dst, ...).",
+      "The destination argument of write_json must be fallback_blocks_dst.",
       "Add write_json(list(), fallback_blocks_dst, auto_unbox=TRUE) in the else branch. Fixes #141 #168."
     )
   )


### PR DESCRIPTION
## Summary

- **#154** `inst/scripts/export_dashboard_data.R`: fix empty-object `{}` bypass in optional schema guard. `jsonlite::fromJSON("{}")` returns a named list with `names = character(0)` (length 0 but NOT NULL), so the old `length(names(parsed)) > 0L` guard incorrectly accepted `{}` as a valid JSON array. Fixed to `!is.null(names(parsed))`. Added a behavioural test covering `[]` (pass), `{}` (reject), scalar (reject).
- **#155** `tests/testthat/test-email-nan-guard.R`: (a) wrap expected-failing `system2()` call with `suppressWarnings()` so testthat does not emit a spurious warning on non-zero exit; (b) add `system.file("scripts", ..., package = "llmtelemetry")` as primary path for `qa_email_output.sh` so tests work in installed/R CMD CHECK contexts, with getwd()-relative paths as fallbacks.
- **#168** `tests/testthat/test-export-dashboard-data.R`: narrow `has_write_json_fallback` check. Old assertion searched from first `} else {` to EOF (~1500 lines), letting any unrelated `write_json` elsewhere satisfy it. New assertion locates `fallback_blocks_src <-` and checks a 15-line window — the actual fallback branch under test.

## Test plan

- [x] `devtools::test()` passes with 0 failures, 0 warnings (was: 1 warning on email-nan-guard)
- [x] `email-nan-guard` no longer emits warning on the "exits 1" test
- [x] `export-dashboard-data` gains 4 new behavioural tests (one new test block with 4 assertions) — all pass
- [x] Pre-existing skips (plotly/DT not in nix shell) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)