### PR TITLE
fix(telemetry): unblock daily-report refresh push + honest data-age stamp

### DIFF
--- a/exec/refresh_and_preserve.sh
+++ b/exec/refresh_and_preserve.sh
@@ -96,11 +96,17 @@ if [ "$ORIGINAL_BRANCH" != "$MAIN_BRANCH" ]; then
     git checkout "$MAIN_BRANCH" 2>&1 | tee -a "$LOG_FILE"
 fi
 
-# Pull latest changes
-log "Pulling latest changes from origin..."
-if ! git pull origin "$MAIN_BRANCH" 2>&1 | tee -a "$LOG_FILE"; then
-    error_log "Failed to pull from origin"
-    # Continue anyway - we can still update locally
+# Fetch and hard-reset to origin — data is fully regenerated on every run so
+# any local-only auto-refresh commits are disposable.  This self-heals a
+# diverged local branch and prevents non-fast-forward push failures.
+log "Fetching origin/$MAIN_BRANCH and resetting local to match (data regenerated below)..."
+git fetch origin "$MAIN_BRANCH" 2>&1 | tee -a "$LOG_FILE"
+fetch_rc=${PIPESTATUS[0]}
+if [ "$fetch_rc" -ne 0 ]; then
+    error_log "Failed to fetch origin/$MAIN_BRANCH (exit $fetch_rc) — continuing with local state"
+else
+    git reset --hard "origin/$MAIN_BRANCH" 2>&1 | tee -a "$LOG_FILE"
+    log "Reset local $MAIN_BRANCH to origin/$MAIN_BRANCH"
 fi
 
 # 1. Archive current JSON files (in case something goes wrong)
@@ -317,19 +323,23 @@ Total cost: \$$TOTAL_COST
 
 🤖 Automated via launchd (12-hourly)"
 
-    if git commit -m "$commit_msg" 2>&1 | tee -a "$LOG_FILE"; then
+    git commit -m "$commit_msg" 2>&1 | tee -a "$LOG_FILE"
+    commit_rc=${PIPESTATUS[0]}
+    if [ "$commit_rc" -eq 0 ]; then
         log "✓ Commit successful"
 
         # Push to remote
         log "Pushing to remote..."
-        if git push origin "$MAIN_BRANCH" 2>&1 | tee -a "$LOG_FILE"; then
+        git push origin "$MAIN_BRANCH" 2>&1 | tee -a "$LOG_FILE"
+        push_rc=${PIPESTATUS[0]}
+        if [ "$push_rc" -eq 0 ]; then
             log "✓ Push successful"
         else
-            error_log "Push failed - may need manual intervention"
+            error_log "Push FAILED (git exit $push_rc) — origin/$MAIN_BRANCH may have diverged; refresh data NOT published"
             # Don't exit with error - local commit still succeeded
         fi
     else
-        error_log "Commit failed"
+        error_log "Commit failed (git exit $commit_rc)"
     fi
 fi
 

--- a/inst/scripts/send_daily_email.R
+++ b/inst/scripts/send_daily_email.R
@@ -190,11 +190,32 @@ accent_blue <- "#4fc3f7"
 accent_purple <- "#bb86fc"
 accent_orange <- "#ff9800"
 
-# Get cache timestamp
-cache_time <- if (!is.null(session_raw$generatedAt)) {
-  session_raw$generatedAt
-} else if (file.exists("inst/extdata/ccusage_session_all.json")) {
-  format(file.info("inst/extdata/ccusage_session_all.json")$mtime, "%Y-%m-%d %H:%M:%S")
+# Get data-age timestamp — reflects the newest record in the data, not the
+# file mtime (which equals checkout time in CI and would mask staleness).
+# Priority: generatedAt from session JSON → latest block actualEndTime/endTime
+#           → latest daily date → "Unknown".
+cache_time <- if (!is.null(session_raw$generatedAt) &&
+                  nchar(as.character(session_raw$generatedAt)) > 0) {
+  as.character(session_raw$generatedAt)
+} else if (!is.null(blocks_raw$blocks) && nrow(blocks_raw$blocks) > 0) {
+  # Use the most recent block end time present in the data
+  blocks_df_ts <- as_tibble(blocks_raw$blocks)
+  end_col <- if ("actualEndTime" %in% names(blocks_df_ts)) "actualEndTime" else "endTime"
+  max_ts <- tryCatch(
+    max(lubridate::ymd_hms(blocks_df_ts[[end_col]], quiet = TRUE), na.rm = TRUE),
+    error = function(e) NA
+  )
+  if (!is.na(max_ts) && is.finite(max_ts)) {
+    format(max_ts, "%Y-%m-%d %H:%M:%S")
+  } else {
+    "Unknown"
+  }
+} else if (!is.null(daily_data) && nrow(daily_data) > 0 && "date" %in% names(daily_data)) {
+  max_date <- tryCatch(
+    max(safe_date(daily_data$date), na.rm = TRUE),
+    error = function(e) NA
+  )
+  if (!is.na(max_date)) as.character(max_date) else "Unknown"
 } else {
   "Unknown"
 }
@@ -581,7 +602,7 @@ if (!has_data) {
 
   email_header <- sprintf('\n<div style="background-color: %s; color: %s; padding: 20px; font-family: -apple-system, BlinkMacSystemFont, sans-serif;">
 <h2 style="color: %s; margin-bottom: 5px;">LLM Usage Report - %s</h2>
-<p style="color: %s; font-size: 12px; margin-top: 0;">Data cached: %s</p>
+<p style="color: %s; font-size: 12px; margin-top: 0;">Data through: %s</p>
 
 <!-- Embedded Dashboard Link -->
 <div style="margin-bottom: 20px;">


### PR DESCRIPTION
## Summary

- **Root cause**: The laptop cron (`exec/refresh_and_preserve.sh`) was silently failing to push to `origin/main` for days. A diverged local branch caused non-fast-forward rejections, but the script logged `✓ Push successful` because `if git push ... | tee; then` reads `tee`'s exit code (always 0), not git's. `origin/main` froze at 4-day-stale data.
- **Symptom compounded by**: `send_daily_email.R` derived `cache_time` from the JSON file's mtime. In CI, mtime == checkout time == "now", so the staleness warning (`>24h old`) never fired and the email looked freshly cached.

## Changes

### `exec/refresh_and_preserve.sh`
- **Self-heal divergence**: replaced `git pull origin main` with `git fetch` + `git reset --hard origin/main`. Since the script regenerates all data fresh on every run, any local-only auto-refresh commits are disposable — hard reset always produces a fast-forward state before committing new data.
- **Honest exit codes**: replaced `if git commit ... | tee; then` and `if git push ... | tee; then` with `${PIPESTATUS[0]}`-after-pipe pattern. A rejected push now logs `Push FAILED (git exit N)` instead of `Push successful`.
- **No global `set -o pipefail`**: the script has many intentional `| tee` and `2>/dev/null` pipes handled by if/else — global pipefail + `set -e` would cause spurious early exits.

### `inst/scripts/send_daily_email.R`
- **Honest data-age stamp**: `cache_time` is now derived from the newest block `actualEndTime` in the loaded data (falls back to latest daily date, then "Unknown"). Previously used file mtime which equals checkout time in CI, masking up to weeks of staleness.
- **Honest label**: `Data cached:` → `Data through:` to reflect that the value is the age of the most recent record, not a generation timestamp.
- **Staleness warning now meaningful**: the existing `>24h` staleness check now fires correctly when data hasn't been refreshed in over a day.

## Verification

`cache_time` from the committed JSON (newest `actualEndTime` in blocks):
```
cache_time = 2026-05-20 20:31:23
```
Old method (file mtime in this worktree): `2026-05-24 10:40:42` — demonstrating the 4-day masking.

Tests: `test-email-nan-guard.R` PASS 44/44, `test-email-codex-section.R` PASS 24/24.

## Operational note

The diverged laptop checkout that originally caused the push failures still needs a one-time manual reset: `git -C <laptop-checkout> fetch origin main && git -C <laptop-checkout> reset --hard origin/main`. This is handled separately by the orchestrator — this PR prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)