### PR TITLE
fix(dashboard): Metric Definitions tabset + robust Mermaid render

### DIFF
--- a/vignettes/dashboard_shinylive.qmd
+++ b/vignettes/dashboard_shinylive.qmd
@@ -597,10 +597,15 @@ ui <- page_navbar(
     ")),
     tags$script(HTML("
       // Mermaid + Tippy init for architecture diagram (Glossary tab, issue #176)
-      // Fix: startOnLoad:false prevents premature render while tab is display:none.
-      // Rendering is deferred to renderVisibleMermaid(), which is called on
-      // shown.bs.tab (Bootstrap 5 tab-show event) and after Shinylive injects the DOM.
+      // Robust render approach (attempt 3): setInterval polls until element is
+      // visible AND mermaid is loaded — catches WASM/tab-show timing regardless
+      // of which event fires first. Prior attempts (startOnLoad:false +
+      // shown.bs.tab) left the diagram blank because mermaid processed the node
+      // while it was 0-width (hidden tab), producing no SVG output.
       var _mermaidInitialized = false;
+      var _archIntervalId = null;
+      var _archIntervalAttempts = 0;
+
       function ensureMermaidInit() {
         if (typeof mermaid === 'undefined') { return false; }
         if (!_mermaidInitialized) {
@@ -608,31 +613,60 @@ ui <- page_navbar(
             startOnLoad: false,
             securityLevel: 'loose',
             theme: 'dark',
-            themeVariables: { fontSize: '14px', lineColor: '#7cb5ec' }
+            themeVariables: { fontSize: '16px', lineColor: '#7cb5ec' }
+          });
+          // Store original definition text in data-mmd-src for safe re-render
+          document.querySelectorAll('.arch-mermaid-wrap .mermaid').forEach(function(el) {
+            if (!el.getAttribute('data-mmd-src')) {
+              el.setAttribute('data-mmd-src', el.textContent);
+            }
           });
           _mermaidInitialized = true;
         }
         return true;
       }
-      function renderVisibleMermaid() {
-        if (!ensureMermaidInit()) {
-          // CDN script not yet loaded — retry shortly
-          setTimeout(renderVisibleMermaid, 300);
-          return;
-        }
+
+      function renderArchMermaid() {
+        if (typeof mermaid === 'undefined') { return; }
+        if (!ensureMermaidInit()) { return; }
         var blocks = document.querySelectorAll('.arch-mermaid-wrap .mermaid');
         blocks.forEach(function(el) {
-          // Only render blocks that are currently visible (not in a display:none container)
-          if (el.offsetParent === null) { return; }
-          // Clear premature 'data-processed' marker set while block was hidden
-          if (el.getAttribute('data-processed') === 'true' && !el.querySelector('svg')) {
-            el.removeAttribute('data-processed');
-          }
+          // Only render when element is actually visible and has non-zero width
+          if (el.offsetParent === null || el.offsetWidth === 0) { return; }
           // Skip if already rendered (has an SVG child)
           if (el.querySelector('svg')) { return; }
-          mermaid.run({ nodes: [el] });
+          // Restore original definition text (in case mermaid blanked it on hidden render)
+          var src = el.getAttribute('data-mmd-src');
+          if (src) { el.textContent = src; }
+          // Clear stale data-processed flag to allow re-render
+          el.removeAttribute('data-processed');
+          try {
+            mermaid.run({ nodes: [el] });
+          } catch(e) {
+            console.error('renderArchMermaid error:', e);
+          }
         });
       }
+
+      function stopArchInterval() {
+        if (_archIntervalId !== null) {
+          clearInterval(_archIntervalId);
+          _archIntervalId = null;
+        }
+      }
+
+      function startArchInterval() {
+        if (_archIntervalId !== null) { return; }  // already running
+        _archIntervalAttempts = 0;
+        _archIntervalId = setInterval(function() {
+          _archIntervalAttempts++;
+          renderArchMermaid();
+          // Stop once SVG rendered OR after ~30 attempts (~18 s)
+          var rendered = document.querySelector('.arch-mermaid-wrap .mermaid svg');
+          if (rendered || _archIntervalAttempts >= 30) { stopArchInterval(); }
+        }, 600);
+      }
+
       function initArchTippy() {
         if (typeof tippy === 'undefined') { setTimeout(initArchTippy, 300); return; }
         document.querySelectorAll('[data-arch-tip]').forEach(function(el) {
@@ -647,29 +681,39 @@ ui <- page_navbar(
           });
         });
       }
-      // Render when any Bootstrap 5 tab becomes visible (covers Reference tab and Glossary inner tab)
+
+      // Trigger 1: Bootstrap 5 tab-show event (covers Reference tab and Glossary inner tab)
       document.addEventListener('shown.bs.tab', function() {
-        setTimeout(renderVisibleMermaid, 100);
+        renderArchMermaid();
+        startArchInterval();
       });
-      // After Shinylive injects the app DOM, attempt render and Tippy init.
-      // MutationObserver fires once when child nodes are added to body (app shell appears).
+
+      // Trigger 2: shiny:idle (fires repeatedly when Shiny is idle — catches late renders)
+      document.addEventListener('shiny:idle', function() {
+        renderArchMermaid();
+        startArchInterval();
+        initArchTippy();
+      });
+
+      // Trigger 3: MutationObserver fires when Shinylive injects the app DOM
       var _archObserver = new MutationObserver(function(mutations, obs) {
         var hasApp = document.querySelector('.arch-mermaid-wrap');
         if (hasApp) {
           obs.disconnect();
-          setTimeout(renderVisibleMermaid, 200);
+          // Store src attributes now that DOM is ready
+          if (!_mermaidInitialized) { ensureMermaidInit(); }
+          setTimeout(renderArchMermaid, 200);
+          setTimeout(startArchInterval, 400);
           setTimeout(initArchTippy, 800);
         }
       });
       _archObserver.observe(document.body, { childList: true, subtree: true });
-      // Fallback: also try on shiny:connected and shiny:idle in case observer misses
+
+      // Trigger 4: shiny:connected (belt-and-suspenders)
       document.addEventListener('shiny:connected', function() {
-        setTimeout(renderVisibleMermaid, 400);
+        setTimeout(renderArchMermaid, 400);
+        setTimeout(startArchInterval, 600);
         setTimeout(initArchTippy, 600);
-      });
-      document.addEventListener('shiny:idle', function() {
-        renderVisibleMermaid();
-        initArchTippy();
       });
     ")),
     # Phase 2B: DuckDB-WASM — initialise once, expose queryAndRenderSessions() globally.
@@ -1353,67 +1397,75 @@ flowchart LR
         ),
         card(card_header("Metric Definitions"),
           tags$div(class = "p-3", style = "color: #e0e0e0; font-size: 0.9em;",
-            tags$h5("Cost Metrics"),
-            tags$dl(
-              tags$dt("Total Cost ($)"), tags$dd("Sum of API charges for input, output, and cache tokens. ",
-                tags$a(href = "https://docs.anthropic.com/en/docs/about-claude/models/overview#api-models", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[Anthropic pricing]")),
-              tags$dt("Cost per MTok"), tags$dd("Cost per million tokens — efficiency metric comparing model tiers."),
-              tags$dt("Cumulative Cost"), tags$dd("Running total of spend over time. Useful for burn-rate forecasting."),
-              tags$dt("Est. Cost by Project"), tags$dd("⚠ Approximate: daily cost × (project session time / total session time). No per-project billing from API.")
-            ),
-            tags$h5("Token Metrics"),
-            tags$dl(
-              tags$dt("Input Tokens"), tags$dd("Tokens sent to the model (prompts, context)."),
-              tags$dt("Output Tokens"), tags$dd("Tokens generated by the model (responses)."),
-              tags$dt("Cache Creation"), tags$dd("Tokens written to prompt cache (first use). Billed at 25% of base input rate. ",
-                tags$a(href = "https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[Anthropic caching docs]")),
-              tags$dt("Cache Read"), tags$dd("Tokens retrieved from cache (subsequent uses). Billed at 10% of base input rate — significant cost saving for repeated context. ",
-                tags$a(href = "https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[Anthropic caching docs]"))
-            ),
-            tags$h5("Session Metrics"),
-            tags$dl(
-              tags$dt("API Conversation"), tags$dd("Single Claude Code conversation. Short durations (0-5 min) are normal — each context compaction or restart creates a new conversation. ",
-                tags$a(href = "https://docs.anthropic.com/en/docs/claude-code/overview", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[Claude Code docs]")),
-              tags$dt("Duration (min)"), tags$dd("Time from conversation start to end. NOT user work time — excludes idle periods between messages."),
-              tags$dt("Block"), tags$dd("Contiguous coding period from ccusage; gaps >30 min create new blocks. More meaningful than API conversations as a work-session metric. ",
-                tags$a(href = "https://github.com/ryoppippi/ccusage", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[ccusage]"))
-            ),
-            tags$h5("Repo Health Metrics"),
-            tags$dl(
-              tags$dt("Bus Factor"), tags$dd("Risk metric: if 1 person has >60% of commits, project is at risk if they leave. Low bus factor = knowledge concentration. ",
-                tags$a(href = "https://en.wikipedia.org/wiki/Bus_factor", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[Wikipedia]")),
-              tags$dt("Velocity Trend"), tags$dd("Commits per month — indicates project momentum. Declining velocity may signal reduced activity or scope completion."),
-              tags$dt("Commit Timing"), tags$dd("Heatmap of when commits happen by hour and day. Shows work patterns and potential burnout signals."),
-              tags$dt("File Growth"), tags$dd("6-month rolling aggregate of files added vs deleted. Net positive = codebase growing."),
-              tags$dt("Churn Hotspots"), tags$dd("Files modified most often. High churn = refactoring candidates or unstable design. ",
-                tags$a(href = "https://en.wikipedia.org/wiki/Software_entropy", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[Software entropy]")),
-              tags$dt("Bug Hotspots"), tags$dd("Files frequently touched by fix/bug commits. May indicate code quality issues."),
-              tags$dt("TODO/FIXME Debt"), tags$dd("Count of TODO, FIXME, HACK markers. Technical debt that should be tracked and resolved. ",
-                tags$a(href = "https://en.wikipedia.org/wiki/Technical_debt", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[Technical debt]")),
-              tags$dt("Crisis Commits"), tags$dd("Reverts, hotfixes, emergency commits. High count = unstable releases or reactive development culture.")
-            ),
-            tags$h5("Calibration Metrics"),
-            tags$dl(
-              tags$dt("Calibration"), tags$dd("How well predicted confidence matches actual outcomes. 80% confident predictions should succeed ~80% of the time. ",
-                tags$a(href = "https://en.wikipedia.org/wiki/Calibration_(statistics)", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[Wikipedia]")),
-              tags$dt("Brier Score"), tags$dd("Mean squared error of probabilistic predictions. 0 = perfect, 0.25 = no better than guessing 50%. Lower is better. ",
-                tags$a(href = "https://en.wikipedia.org/wiki/Brier_score", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[Wikipedia]")),
-              tags$dt("Reliability Diagram"), tags$dd("Plot of predicted confidence vs actual success rate. Points on diagonal = perfectly calibrated. Above = overconfident. Below = underconfident."),
-              tags$dt("Overconfidence"), tags$dd("Predictions above the reliability diagram diagonal — stated confidence exceeds actual accuracy."),
-              tags$dt("Underconfidence"), tags$dd("Predictions below the diagonal — actual accuracy exceeds stated confidence (rare but possible).")
-            ),
-            tags$h5("Tools"),
-            tags$dl(
-              tags$dt("Shinylive"), tags$dd("R Shiny apps running entirely in the browser via WebAssembly — no server required. ",
-                tags$a(href = "https://posit-dev.github.io/r-shinylive/", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[posit-dev.github.io]")),
-              tags$dt("WebR / WebAssembly"), tags$dd("R compiled to WebAssembly, running natively in the browser. Powers the Shinylive embedding in this dashboard. ",
-                tags$a(href = "https://docs.r-wasm.org/webr/latest/", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[docs.r-wasm.org]")),
-              tags$dt("DuckDB-WASM"), tags$dd("DuckDB compiled to WebAssembly — SQL analytics in the browser, no server. Used here for Parquet queries. ",
-                tags$a(href = "https://duckdb.org/docs/clients/wasm/overview.html", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[DuckDB WASM docs]")),
-              tags$dt("duckplyr"), tags$dd("Tidyverse-syntax DuckDB queries in R — replaces raw SQL strings. ",
-                tags$a(href = "https://duckplyr.tidyverse.org/", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[duckplyr.tidyverse.org]")),
-              tags$dt("ECharts"), tags$dd("Apache ECharts — the JavaScript charting library powering all interactive charts. ",
-                tags$a(href = "https://echarts.apache.org/en/index.html", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[echarts.apache.org]"))
+            navset_tab(
+              nav_panel("Cost",
+                tags$dl(class = "mt-2",
+                  tags$dt("Total Cost ($)"), tags$dd("Sum of API charges for input, output, and cache tokens. ",
+                    tags$a(href = "https://docs.anthropic.com/en/docs/about-claude/models/overview#api-models", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[Anthropic pricing]")),
+                  tags$dt("Cost per MTok"), tags$dd("Cost per million tokens — efficiency metric comparing model tiers."),
+                  tags$dt("Cumulative Cost"), tags$dd("Running total of spend over time. Useful for burn-rate forecasting."),
+                  tags$dt("Est. Cost by Project"), tags$dd("⚠ Approximate: daily cost × (project session time / total session time). No per-project billing from API.")
+                )
+              ),
+              nav_panel("Tokens",
+                tags$dl(class = "mt-2",
+                  tags$dt("Input Tokens"), tags$dd("Tokens sent to the model (prompts, context)."),
+                  tags$dt("Output Tokens"), tags$dd("Tokens generated by the model (responses)."),
+                  tags$dt("Cache Creation"), tags$dd("Tokens written to prompt cache (first use). Billed at 25% of base input rate. ",
+                    tags$a(href = "https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[Anthropic caching docs]")),
+                  tags$dt("Cache Read"), tags$dd("Tokens retrieved from cache (subsequent uses). Billed at 10% of base input rate — significant cost saving for repeated context. ",
+                    tags$a(href = "https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[Anthropic caching docs]"))
+                )
+              ),
+              nav_panel("Sessions",
+                tags$dl(class = "mt-2",
+                  tags$dt("API Conversation"), tags$dd("Single Claude Code conversation. Short durations (0-5 min) are normal — each context compaction or restart creates a new conversation. ",
+                    tags$a(href = "https://docs.anthropic.com/en/docs/claude-code/overview", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[Claude Code docs]")),
+                  tags$dt("Duration (min)"), tags$dd("Time from conversation start to end. NOT user work time — excludes idle periods between messages."),
+                  tags$dt("Block"), tags$dd("Contiguous coding period from ccusage; gaps >30 min create new blocks. More meaningful than API conversations as a work-session metric. ",
+                    tags$a(href = "https://github.com/ryoppippi/ccusage", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[ccusage]"))
+                )
+              ),
+              nav_panel("Git",
+                tags$dl(class = "mt-2",
+                  tags$dt("Bus Factor"), tags$dd("Risk metric: if 1 person has >60% of commits, project is at risk if they leave. Low bus factor = knowledge concentration. ",
+                    tags$a(href = "https://en.wikipedia.org/wiki/Bus_factor", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[Wikipedia]")),
+                  tags$dt("Velocity Trend"), tags$dd("Commits per month — indicates project momentum. Declining velocity may signal reduced activity or scope completion."),
+                  tags$dt("Commit Timing"), tags$dd("Heatmap of when commits happen by hour and day. Shows work patterns and potential burnout signals."),
+                  tags$dt("File Growth"), tags$dd("6-month rolling aggregate of files added vs deleted. Net positive = codebase growing."),
+                  tags$dt("Churn Hotspots"), tags$dd("Files modified most often. High churn = refactoring candidates or unstable design. ",
+                    tags$a(href = "https://en.wikipedia.org/wiki/Software_entropy", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[Software entropy]")),
+                  tags$dt("Bug Hotspots"), tags$dd("Files frequently touched by fix/bug commits. May indicate code quality issues."),
+                  tags$dt("TODO/FIXME Debt"), tags$dd("Count of TODO, FIXME, HACK markers. Technical debt that should be tracked and resolved. ",
+                    tags$a(href = "https://en.wikipedia.org/wiki/Technical_debt", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[Technical debt]")),
+                  tags$dt("Crisis Commits"), tags$dd("Reverts, hotfixes, emergency commits. High count = unstable releases or reactive development culture.")
+                )
+              ),
+              nav_panel("Calibration",
+                tags$dl(class = "mt-2",
+                  tags$dt("Calibration"), tags$dd("How well predicted confidence matches actual outcomes. 80% confident predictions should succeed ~80% of the time. ",
+                    tags$a(href = "https://en.wikipedia.org/wiki/Calibration_(statistics)", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[Wikipedia]")),
+                  tags$dt("Brier Score"), tags$dd("Mean squared error of probabilistic predictions. 0 = perfect, 0.25 = no better than guessing 50%. Lower is better. ",
+                    tags$a(href = "https://en.wikipedia.org/wiki/Brier_score", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[Wikipedia]")),
+                  tags$dt("Reliability Diagram"), tags$dd("Plot of predicted confidence vs actual success rate. Points on diagonal = perfectly calibrated. Above = overconfident. Below = underconfident."),
+                  tags$dt("Overconfidence"), tags$dd("Predictions above the reliability diagram diagonal — stated confidence exceeds actual accuracy."),
+                  tags$dt("Underconfidence"), tags$dd("Predictions below the diagonal — actual accuracy exceeds stated confidence (rare but possible).")
+                )
+              ),
+              nav_panel("Tools",
+                tags$dl(class = "mt-2",
+                  tags$dt("Shinylive"), tags$dd("R Shiny apps running entirely in the browser via WebAssembly — no server required. ",
+                    tags$a(href = "https://posit-dev.github.io/r-shinylive/", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[posit-dev.github.io]")),
+                  tags$dt("WebR / WebAssembly"), tags$dd("R compiled to WebAssembly, running natively in the browser. Powers the Shinylive embedding in this dashboard. ",
+                    tags$a(href = "https://docs.r-wasm.org/webr/latest/", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[docs.r-wasm.org]")),
+                  tags$dt("DuckDB-WASM"), tags$dd("DuckDB compiled to WebAssembly — SQL analytics in the browser, no server. Used here for Parquet queries. ",
+                    tags$a(href = "https://duckdb.org/docs/clients/wasm/overview.html", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[DuckDB WASM docs]")),
+                  tags$dt("duckplyr"), tags$dd("Tidyverse-syntax DuckDB queries in R — replaces raw SQL strings. ",
+                    tags$a(href = "https://duckplyr.tidyverse.org/", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[duckplyr.tidyverse.org]")),
+                  tags$dt("ECharts"), tags$dd("Apache ECharts — the JavaScript charting library powering all interactive charts. ",
+                    tags$a(href = "https://echarts.apache.org/en/index.html", target = "_blank", rel = "noopener noreferrer", style = "color:#7cb5ec;", "[echarts.apache.org]"))
+                )
+              )
             )
           ),
           card_footer(class = "text-muted small",


### PR DESCRIPTION
## Summary

- **Metric Definitions tabset**: The flat \`h5\` + \`dl\` layout in the Glossary card has been replaced with a \`navset_tab()\` containing 6 category tabs:
  - **Cost**: Total Cost (\$), Cost per MTok, Cumulative Cost, Est. Cost by Project
  - **Tokens**: Input Tokens, Output Tokens, Cache Creation, Cache Read
  - **Sessions**: API Conversation, Duration (min), Block
  - **Git**: Bus Factor, Velocity Trend, Commit Timing, File Growth, Churn Hotspots, Bug Hotspots, TODO/FIXME Debt, Crisis Commits
  - **Calibration**: Calibration, Brier Score, Reliability Diagram, Overconfidence, Underconfidence
  - **Tools**: Shinylive, WebR / WebAssembly, DuckDB-WASM, duckplyr, ECharts
  - All 22 original dt/dd terms preserved verbatim; no content dropped.

- **Mermaid Architecture diagram (robust render fix)**: Prior approaches (`startOnLoad:false` + `shown.bs.tab`) left the diagram blank because Mermaid processed the node while it was 0-width (hidden tab). The new approach:
  - Stores each `.arch-mermaid-wrap .mermaid` element's original definition text in `data-mmd-src` at init time
  - `renderArchMermaid()` only runs on visible elements (`offsetWidth > 0`), restores `textContent` from `data-mmd-src`, removes `data-processed`, then calls `mermaid.run({ nodes: [el] })`
  - A `setInterval(..., 600)` polls up to 30 times (~18 s) and stops once an `<svg>` child appears — catches the moment the tab becomes visible regardless of event timing
  - Four trigger hooks: `shown.bs.tab`, `shiny:idle`, `MutationObserver`, `shiny:connected`
  - **Client-side browser verification required**: hard-refresh (Ctrl+Shift+R / Cmd+Shift+R) to bypass service worker cache, then open Reference → Glossary tab and check DevTools console for errors.

## Test plan

- [ ] Hard-refresh the live dashboard (clear service-worker cache) after CI deploys
- [ ] Navigate to Reference → Glossary; confirm Metric Definitions card shows tabs (Cost / Tokens / Sessions / Git / Calibration / Tools)
- [ ] Click each tab and confirm definitions appear with correct content
- [ ] Navigate to Reference → Glossary; confirm Architecture diagram renders as an SVG (not blank)
- [ ] Open DevTools console; confirm no `renderArchMermaid error:` messages
- [ ] Confirm R parse: `PARSE OK` (run in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)