### PR TITLE
fix(dashboard): in-page tabset partitioning for Usage (#175)

### DIFF
--- a/vignettes/dashboard_shinylive.qmd
+++ b/vignettes/dashboard_shinylive.qmd
@@ -1042,68 +1042,82 @@ ui <- page_navbar(
         )
       ),
       nav_panel("Sessions", value = "Sessions",
-        layout_columns(col_widths = c(12),
-          card(
-            card_header("Sessions Summary"),
-            tags$table(class = "table table-sm table-dark mb-0",
-              tags$thead(tags$tr(tags$th("Metric"), tags$th("Value"))),
-              tags$tbody(
-                tooltip(
-                  tags$tr(tags$td("API Conversations"), tags$td(textOutput("vb_sess_count", inline = TRUE))),
-                  "Count of Claude Code conversations (each restart = new session)"
+        navset_pill(
+          nav_panel("Charts",
+            layout_columns(col_widths = c(12),
+              card(
+                card_header("Sessions Summary"),
+                tags$table(class = "table table-sm table-dark mb-0",
+                  tags$thead(tags$tr(tags$th("Metric"), tags$th("Value"))),
+                  tags$tbody(
+                    tooltip(
+                      tags$tr(tags$td("API Conversations"), tags$td(textOutput("vb_sess_count", inline = TRUE))),
+                      "Count of Claude Code conversations (each restart = new session)"
+                    ),
+                    tooltip(
+                      tags$tr(tags$td("Total Duration"), tags$td(textOutput("vb_sess_duration", inline = TRUE))),
+                      "Sum of all conversation durations (minutes)"
+                    ),
+                    tooltip(
+                      tags$tr(tags$td("Avg Duration"), tags$td(textOutput("vb_sess_avg", inline = TRUE))),
+                      "Average conversation length (minutes)"
+                    )
+                  )
                 ),
-                tooltip(
-                  tags$tr(tags$td("Total Duration"), tags$td(textOutput("vb_sess_duration", inline = TRUE))),
-                  "Sum of all conversation durations (minutes)"
-                ),
-                tooltip(
-                  tags$tr(tags$td("Avg Duration"), tags$td(textOutput("vb_sess_avg", inline = TRUE))),
-                  "Average conversation length (minutes)"
-                )
+                card_footer(class = "text-muted small",
+                  "Session counts from Claude Code hook telemetry (unified.duckdb). A session = one continuous coding session; each restart or context compaction creates a new entry.")
               )
             ),
-            card_footer(class = "text-muted small",
-              "Session counts from Claude Code hook telemetry (unified.duckdb). A session = one continuous coding session; each restart or context compaction creates a new entry.")
+            layout_columns(col_widths = c(6, 6),
+              card(card_header("Conversation Duration Distribution"), uiOutput("sess_hist"),
+                card_footer(class = "text-muted small", "Histogram of API conversation durations (minutes)")),
+              card(card_header("Conversations Over Time"), uiOutput("sess_scatter"),
+                card_footer(class = "text-muted small", "Daily conversation count, bubble size = total minutes"))
+            )
+          ),
+          nav_panel("Tables",
+            layout_columns(col_widths = c(6, 6),
+              card(card_header("Recent API Conversations"), DTOutput("sess_claude"),
+                card_footer(class = "text-muted small", "⚠ These are API conversations, not work sessions. Each Claude Code restart = new conversation. Short durations are normal.")),
+              card(card_header("Top Gemini Sessions"), DTOutput("sess_gemini"),
+                card_footer(class = "text-muted small", "Most expensive Gemini sessions by total cost"))
+            )
           )
-        ),
-        layout_columns(col_widths = c(6, 6),
-          card(card_header("Recent API Conversations"), DTOutput("sess_claude"),
-            card_footer(class = "text-muted small", "⚠ These are API conversations, not work sessions. Each Claude Code restart = new conversation. Short durations are normal.")),
-          card(card_header("Top Gemini Sessions"), DTOutput("sess_gemini"),
-            card_footer(class = "text-muted small", "Most expensive Gemini sessions by total cost"))
-        ),
-        layout_columns(col_widths = c(6, 6),
-          card(card_header("Conversation Duration Distribution"), uiOutput("sess_hist"),
-            card_footer(class = "text-muted small", "Histogram of API conversation durations (minutes)")),
-          card(card_header("Conversations Over Time"), uiOutput("sess_scatter"),
-            card_footer(class = "text-muted small", "Daily conversation count, bubble size = total minutes"))
         )
       ),
       nav_panel("By Project", value = "By Project",
-        layout_columns(col_widths = c(6, 6),
-          card(card_header("Estimated Cost by Project"), uiOutput("proj_cost_total"),
-            card_footer(class = "text-muted small", "Session-weighted cost estimate (⚠ approximate)")),
-          card(card_header("Sessions by Project"),
-            tags$div(id="proj_sessions_ec", class="echart-div", style="width:100%;height:300px;"),
-            card_footer(class = "text-muted small", "Session count per project · powered by DuckDB-WASM"))
-        ),
-        layout_columns(col_widths = c(12),
-          card(card_header("Daily Cost Trend by Project"), uiOutput("proj_cost_daily"),
-            card_footer(class = "text-muted small", "Stacked area chart of estimated daily costs"))
-        ),
-        layout_columns(col_widths = c(12),
-          card(card_header("Cumulative Daily Cost Trend by Project"), uiOutput("proj_cost_cumulative"),
-            card_footer(class = "text-muted small", "Running total of estimated daily costs by project"))
-        ),
-        layout_columns(col_widths = c(6, 6),
-          card(card_header("Session Duration by Project"), uiOutput("proj_duration"),
-            card_footer(class = "text-muted small", "Total session minutes per project")),
-          card(card_header("Cost Share by Date"), uiOutput("proj_share_heatmap"),
-            card_footer(class = "text-muted small", "Heatmap: project cost share by date"))
-        ),
-        layout_columns(col_widths = c(12),
-          card(card_header("Weekly Commit Heatmap"), uiOutput("proj_weekly_heatmap"),
-            card_footer(class = "text-muted small", "Weekly commit counts across tracked repos. X = ISO week, Y = project, colour = commit count. Default view: last 13 weeks."))
+        navset_pill(
+          nav_panel("Overview",
+            layout_columns(col_widths = c(6, 6),
+              card(card_header("Estimated Cost by Project"), uiOutput("proj_cost_total"),
+                card_footer(class = "text-muted small", "Session-weighted cost estimate (⚠ approximate)")),
+              card(card_header("Sessions by Project"),
+                tags$div(id="proj_sessions_ec", class="echart-div", style="width:100%;height:300px;"),
+                card_footer(class = "text-muted small", "Session count per project · powered by DuckDB-WASM"))
+            )
+          ),
+          nav_panel("Trends",
+            layout_columns(col_widths = c(12),
+              card(card_header("Daily Cost Trend by Project"), uiOutput("proj_cost_daily"),
+                card_footer(class = "text-muted small", "Stacked area chart of estimated daily costs"))
+            ),
+            layout_columns(col_widths = c(12),
+              card(card_header("Cumulative Daily Cost Trend by Project"), uiOutput("proj_cost_cumulative"),
+                card_footer(class = "text-muted small", "Running total of estimated daily costs by project"))
+            )
+          ),
+          nav_panel("Details",
+            layout_columns(col_widths = c(6, 6),
+              card(card_header("Session Duration by Project"), uiOutput("proj_duration"),
+                card_footer(class = "text-muted small", "Total session minutes per project")),
+              card(card_header("Cost Share by Date"), uiOutput("proj_share_heatmap"),
+                card_footer(class = "text-muted small", "Heatmap: project cost share by date"))
+            ),
+            layout_columns(col_widths = c(12),
+              card(card_header("Weekly Commit Heatmap"), uiOutput("proj_weekly_heatmap"),
+                card_footer(class = "text-muted small", "Weekly commit counts across tracked repos. X = ISO week, Y = project, colour = commit count. Default view: last 13 weeks."))
+            )
+          )
         )
       )
     )


### PR DESCRIPTION
## Summary

Partitioned the two most cluttered Usage sub-tabs into nested `navset_pill()` views:

**Sessions** (5 cards → 2 nested pills):
- "Charts": Sessions Summary + Duration Distribution + Conversations Over Time
- "Tables": Recent API Conversations + Top Gemini Sessions

**By Project** (7 cards → 3 nested pills):
- "Overview": Estimated Cost by Project + Sessions by Project
- "Trends": Daily Cost Trend by Project + Cumulative Daily Cost Trend
- "Details": Session Duration by Project + Cost Share by Date + Weekly Commit Heatmap

All output IDs moved byte-for-byte — no IDs added or removed. `usage_tabs` id and all existing sub-tab `value=` strings unchanged. New `navset_pill()` elements have no `id=` (no server/JS references to their values). R parse: PARSE OK.

Part of #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)