### PR TITLE
fix(dashboard): readable mermaid node text + Datasets diagram LR

### DIFF
--- a/vignettes/dashboard_shinylive.qmd
+++ b/vignettes/dashboard_shinylive.qmd
@@ -589,6 +589,10 @@ ui <- page_navbar(
       /* Architecture diagram Mermaid sizing */
       .arch-mermaid-wrap { min-height: 560px; }
       .arch-mermaid-wrap .mermaid svg { max-width: 720px; height: auto; display: block; margin: 0 auto; }
+      /* Mermaid node label contrast fix — black text on light node fill (issue: white-on-white) */
+      .arch-mermaid-wrap .mermaid .nodeLabel, .arch-mermaid-wrap .mermaid span { color: #000 !important; }
+      .arch-mermaid-wrap .mermaid text { fill: #000 !important; }
+      .arch-mermaid-wrap .mermaid .edgeLabel { background-color: #fff !important; color: #000 !important; }
       /* Tippy theme overrides — force >=1rem per hover-popup-standard rule */
       .tippy-box[data-theme~='arch'] { font-size: 1rem !important; max-width: 380px !important; }
       .tippy-box[data-theme~='arch'] a { color: #7cb5ec; }
@@ -613,8 +617,20 @@ ui <- page_navbar(
           mermaid.initialize({
             startOnLoad: false,
             securityLevel: 'loose',
-            theme: 'dark',
-            themeVariables: { fontSize: '16px', lineColor: '#7cb5ec' }
+            theme: 'base',
+            themeVariables: {
+              fontSize: '16px',
+              primaryColor: '#e8eef5',
+              primaryTextColor: '#000000',
+              primaryBorderColor: '#4ea8de',
+              lineColor: '#9fb3c8',
+              secondaryColor: '#dde6f0',
+              tertiaryColor: '#eef3f8',
+              tertiaryTextColor: '#000000',
+              secondaryTextColor: '#000000',
+              edgeLabelBackground: '#ffffff',
+              textColor: '#000000'
+            }
           });
           // Store original definition text in data-mmd-src for safe re-render
           document.querySelectorAll('.arch-mermaid-wrap .mermaid').forEach(function(el) {
@@ -1523,7 +1539,7 @@ flowchart TB
         card(card_header("Datasets — Committed Data Files"),
           tags$div(class = "p-3 arch-mermaid-wrap",
             tags$div(class = "mermaid", "
-flowchart TB
+flowchart LR
     ExtData[\"inst/extdata/ — committed data root\"]
     CCDaily[\"ccusage_daily_all.json — daily cost & tokens\"]
     CCSess[\"ccusage_sessions_all.json — per-session records\"]


### PR DESCRIPTION
## Summary

- **White-on-white contrast fix**: Mermaid diagrams in the Reference tab rendered node label text invisible (white on white/light fill). Replaced `theme: 'dark'` with `theme: 'base'` plus explicit `themeVariables` that set a light node fill (`primaryColor: '#e8eef5'`) and force **black text** on all node types (`primaryTextColor`, `textColor`, `secondaryTextColor`, `tertiaryTextColor` all `'#000000'`). Belt-and-suspenders CSS scoped to `.arch-mermaid-wrap` targets `.nodeLabel`, `span`, `text`, and `.edgeLabel`. Contrast ratio is ~14:1 (black on #e8eef5), well above WCAG 4.5:1 minimum.
- **Datasets diagram layout**: Changed `flowchart TB` → `flowchart LR` for the "Datasets — Committed Data Files" card so the 1-root → 7-file-node tree reads left-to-right instead of squeezing all 7 files into one compressed vertical rank. Architecture and Workflow diagrams remain `flowchart TB`.

## Test plan

- [ ] Hard-refresh the dashboard (Shift+Reload or clear service-worker cache) to bypass the Shinylive service-worker cache
- [ ] Navigate to Reference tab → Glossary → Architecture/Workflow cards: node labels should appear in black text on a light grey-blue fill against the dark dashboard background
- [ ] Navigate to Reference tab → Datasets card: diagram should render left-to-right with the root node on the left and 7 file nodes fanning out to the right
- [ ] All three diagrams remain clickable (securityLevel loose preserved)

> Note: client-side render requires browser verification; R parse check passed (PARSE OK) in CI pre-flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)