### PR TITLE
chore: move root shell scripts into scripts/ (#195)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,7 +5,7 @@
 ^default\.nix\.bak
 ^default\.nix\.dup$
 ^package\.nix$
-^push_to_cachix\.sh$
+^scripts/push_to_cachix\.sh$
 ^plans$
 ^\.github$
 ^vignettes$

--- a/default.R
+++ b/default.R
@@ -13,5 +13,5 @@ rix(
   date = "2026-01-05",
   project_path = ".",
   overwrite = TRUE,
-  shell_hook = "echo 'Welcome to llmtelemetry app shell'; source $PWD/.nix-shellhook.sh 2>/dev/null || true"
+  shell_hook = "echo 'Welcome to llmtelemetry app shell'; source $PWD/scripts/nix-shellhook.sh 2>/dev/null || true"
 )

--- a/default.nix
+++ b/default.nix
@@ -29,7 +29,7 @@
 #  > ide = "none",
 #  > project_path = ".",
 #  > overwrite = TRUE,
-#  > shell_hook = "echo 'Welcome to llmtelemetry app shell'; source $PWD/.nix-shellhook.sh 2>/dev/null || true",
+#  > shell_hook = "echo 'Welcome to llmtelemetry app shell'; source $PWD/scripts/nix-shellhook.sh 2>/dev/null || true",
 #  > r_ver = "4.5.2")
 # It uses the `rstats-on-nix` fork of `nixpkgs` which provides improved
 # compatibility with older R versions and R packages for Linux/WSL and
@@ -85,7 +85,7 @@ let
     
     buildInputs = [ rpkgs system_packages ];
     shellHook = ''
-    echo 'Welcome to llmtelemetry app shell'; source $PWD/.nix-shellhook.sh 2>/dev/null || true
+    echo 'Welcome to llmtelemetry app shell'; source $PWD/scripts/nix-shellhook.sh 2>/dev/null || true
   '';
   }; 
 in

--- a/package.nix
+++ b/package.nix
@@ -1,6 +1,6 @@
 # package.nix - Build llmtelemetry as an installable R package derivation
 #
-# Used by push_to_cachix.sh to build and push to johngavin cachix.
+# Used by scripts/push_to_cachix.sh to build and push to johngavin cachix.
 # Uses same rstats-on-nix pin as default.nix (2026-01-05).
 #
 # Usage:

--- a/scripts/nix-shellhook.sh
+++ b/scripts/nix-shellhook.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# .nix-shellhook.sh — Fix R_LIBS_SITE for nested nix-shell
+# scripts/nix-shellhook.sh — Fix R_LIBS_SITE for nested nix-shell
 # Prevents segfault from ABI mismatch when entering this shell
 # from inside another nix-shell (e.g., global dev shell).
 # See nix-nested-shell-isolation rule.

--- a/scripts/push_to_cachix.sh
+++ b/scripts/push_to_cachix.sh
@@ -10,7 +10,7 @@
 # Step 5 of 9-step workflow. Builds from package.nix, pushes ONE derivation.
 #
 # Usage:
-#   ./push_to_cachix.sh
+#   ./scripts/push_to_cachix.sh
 #
 # Exit codes:
 #   0 - Success


### PR DESCRIPTION
## Summary

- `push_to_cachix.sh` → `scripts/push_to_cachix.sh` (git mv)
- `.nix-shellhook.sh` → `scripts/nix-shellhook.sh` (git mv; dot-prefix dropped — root dotfile convention no longer applies inside `scripts/`)

## References updated

- `.Rbuildignore`: exclusion pattern updated to `^scripts/push_to_cachix\.sh$`
- `package.nix`: comment updated to reference `scripts/push_to_cachix.sh`
- `default.R`: `shell_hook` now sources `$PWD/scripts/nix-shellhook.sh`
- `default.nix`: `shellHook` updated to match (both live code line and the generated-comment header)

## Nix shell verification

`.nix-shellhook.sh` was moved (option a): `(cd worktree && nix-shell default.nix --run "echo shell-ok")` output:

```
Welcome to llmtelemetry app shell
shell-ok
```

Shell enters cleanly with the updated path.

## Grep clean

`git grep` over `*.sh *.yml *.yaml *.md *.nix *.R .Rbuildignore` — no remaining references to old root paths `push_to_cachix.sh` or `.nix-shellhook.sh`.

Closes #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)