### PR TITLE
fix(dashboard): DuckDB-WASM sessions.parquet load path

### DIFF
--- a/vignettes/dashboard_shinylive.qmd
+++ b/vignettes/dashboard_shinylive.qmd
@@ -749,23 +749,33 @@ ui <- page_navbar(
     # Type module gives us top-level await; the Shiny message handler is registered
     # after shiny:connected fires so the message bus is ready.
     # Embedded JS — literal quotes MUST be escaped (single-quoted R string): use \' for each JS '
+    # PARQUET_URL: use the same base-path strategy as load_json() in R — origin-absolute
+    # "/llmtelemetry/data/v1/sessions.parquet". This avoids Shinylive iframe location
+    # ambiguity that made new URL("data/v1/sessions.parquet", window.location.href)
+    # resolve to a wrong path when window.location inside the Shinylive context does
+    # not end with a directory slash (e.g. ".../index.html" drops "data/" prefix).
     tags$script(type = "module", HTML('
-      const PARQUET_URL = new URL("data/v1/sessions.parquet", window.location.href).href;
-      const duckdb = await import("https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.32.0/+esm");
-      const bundle = await duckdb.selectBundle(duckdb.getJsDelivrBundles());
-      const worker = new Worker(
-        URL.createObjectURL(new Blob(
-          ["importScripts(\\"" + bundle.mainWorker + "\\");"],
-          {type:"text/javascript"}
-        ))
-      );
-      const db = new duckdb.AsyncDuckDB(new duckdb.ConsoleLogger(), worker);
-      await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
-      await db.registerFileURL(
-        "sessions.parquet", PARQUET_URL,
-        duckdb.DuckDBDataProtocol.HTTP, false
-      );
-      const conn = await db.connect();
+      const PARQUET_URL = window.location.origin + "/llmtelemetry/data/v1/sessions.parquet";
+      let conn = null;
+      try {
+        const duckdb = await import("https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.32.0/+esm");
+        const bundle = await duckdb.selectBundle(duckdb.getJsDelivrBundles());
+        const worker = new Worker(
+          URL.createObjectURL(new Blob(
+            ["importScripts(\\"" + bundle.mainWorker + "\\");"],
+            {type:"text/javascript"}
+          ))
+        );
+        const db = new duckdb.AsyncDuckDB(new duckdb.ConsoleLogger(), worker);
+        await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
+        await db.registerFileURL(
+          "sessions.parquet", PARQUET_URL,
+          duckdb.DuckDBDataProtocol.HTTP, false
+        );
+        conn = await db.connect();
+      } catch(initErr) {
+        console.error("DuckDB-WASM init failed:", initErr, "PARQUET_URL:", PARQUET_URL);
+      }
 
       let _chart = null;
 
@@ -780,6 +790,17 @@ ui <- page_navbar(
             new ResizeObserver(function() { _chart.resize(); }).observe(el);
           }
           _chart.setOption({ backgroundColor:"#1a1a1a", series:[{type:"bar",data:[]}] }, true);
+          return;
+        }
+        // Graceful empty state if DuckDB-WASM failed to initialise.
+        if (!conn) {
+          const el = document.getElementById("proj_sessions_ec");
+          if (el) {
+            if (!_chart) { _chart = echarts.init(el, "dark"); new ResizeObserver(function(){_chart.resize();}).observe(el); }
+            _chart.setOption({ backgroundColor:"#1a1a1a",
+              title:{text:"Sessions data unavailable",textStyle:{color:"#ccc",fontSize:13}},
+              series:[] }, true);
+          }
           return;
         }
         // projects is null (All — no IN filter, includes live projects absent from master)


### PR DESCRIPTION
## Diagnosis

The sessions.parquet file is correctly deployed at `https://johngavin.github.io/llmtelemetry/data/v1/sessions.parquet` (the CI workflow stages it and the post-deploy verify step confirms HTTP 200). The bug was in how `PARQUET_URL` was constructed inside the Shinylive iframe.

**Before (broken):**
```js
const PARQUET_URL = new URL("data/v1/sessions.parquet", window.location.href).href;
```

Inside the Shinylive context, `window.location.href` may not end with a directory slash (e.g. `.../index.html`), so resolving the relative `"data/v1/sessions.parquet"` against it drops the `data/` directory segment and produces the wrong URL. `registerFileURL()` then registers a bad URL. When the query runs `FROM 'sessions.parquet'`, DuckDB falls back to treating it as a bare filename and fails with:

> `Error: Opening file 'sessions.parquet' failed with error: Failed to open file: sessions.parquet`

## Fix

**After (fixed):**
```js
const PARQUET_URL = window.location.origin + "/llmtelemetry/data/v1/sessions.parquet";
```

This mirrors the R `load_json()` helper's `base_url = "/llmtelemetry/data/"` strategy — using `window.location.origin` + an origin-absolute path that always resolves to the correct deployed URL regardless of how Shinylive sets `window.location`.

Also added:
- `try/catch` around the entire DuckDB-WASM init block — init errors are logged to the console with the resolved `PARQUET_URL` value to aid future debugging
- `conn === null` guard in `queryAndRenderSessions()` — shows a graceful "Sessions data unavailable" empty-state chart instead of an uncaught `TypeError` if init fails

## Verification

- R parse: `PARSE OK` (the modified chunk was verified with `parse(text=...)`)
- Runtime: requires a hard-refresh on the deployed page — check the browser console no longer shows the sessions.parquet error and the By-Project sessions chart renders

Groundwork for #83 Phase E (DuckDB-WASM chart migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)