### PR TITLE
feat(telemetry): PIT cost appender (#83 Phase A, increment 1)

### DIFF
--- a/R/rollup_costs.R
+++ b/R/rollup_costs.R
@@ -248,3 +248,12 @@ append_costs_from_staging <- function(
 
   invisible(nrow(new_rows))
 }
+
+# TODO(#83 Phase A): add costs_amendments.parquet SCD2 correction log — each
+# amendment emits a new row with valid_from/valid_to/reason, never
+# UPDATE/DELETE.  Mirror the design from the epic schema.
+#
+# TODO(#83 Phase A): add a scheduled "drain staging → append → commit parquet"
+# step (launchd/cron or /schedule routine) so valid_from reflects real arrival
+# time rather than a single bulk seed timestamp.  Concurrency guard needed:
+# check for an in-progress .tmp file before starting a new drain.

--- a/R/rollup_sessions.R
+++ b/R/rollup_sessions.R
@@ -279,3 +279,10 @@ append_sessions_from_staging <- function(
 
   invisible(nrow(new_rows))
 }
+
+# TODO(#83 Phase A): add sessions_amendments.parquet SCD2 correction log —
+# each amendment emits a new row with valid_from/valid_to/reason, never
+# UPDATE/DELETE.
+#
+# TODO(#83 Phase A): add a scheduled "drain staging → append → commit parquet"
+# step so valid_from reflects real arrival time rather than a bulk seed.


### PR DESCRIPTION
## Summary

- `append_costs_from_staging()` (in `R/rollup_costs.R`) mirrors `append_sessions_from_staging()` exactly and was already merged to main in feat(#83): Phase 1F (commit `92f63cd`). This PR documents that increment in a dedicated PR and adds TODO markers for the two deferred Phase A follow-ups.
- **Cost source used:** `~/.claude/logs/llmtelemetry-staging` JSONL files, filtering to `event_type == "cost_emitted"` events emitted by `~/.claude/hooks/llmtelemetry_emit.sh` (Phase 3 hook, deployed 2026-05-18).
- **Mirrors sessions appender exactly:** same `read_staging()` reader, same `valid_from` timestamping, same DuckDB-native atomic append (COPY ... TO with zstd, `.tmp` → rename), same idempotent dedup by synthetic key (`cost_id = canonical_project|date|source` vs `session_id`).
- **TODO markers added** in both `rollup_costs.R` and `rollup_sessions.R` for the deferred Phase A work: (1) `*_amendments.parquet` SCD2 correction log, (2) scheduled drain step so `valid_from` reflects real arrival time.

## Cost data flow

```
~/.claude/hooks/llmtelemetry_emit.sh  →  ~/.claude/logs/llmtelemetry-staging/events-YYYY-MM-DD.jsonl
                                                     ↓
                                          read_staging() [reads all *.jsonl]
                                                     ↓ filter: event_type == "cost_emitted"
                                          append_costs_from_staging()
                                                     ↓ dedup by cost_id
                                          inst/extdata/telemetry/v1/costs.parquet
```

## Deferred (Phase A follow-ups, marked with TODO)

- `costs_amendments.parquet` / `sessions_amendments.parquet` SCD2 log (new rows with `valid_from`/`valid_to`/`reason`, never UPDATE/DELETE)
- Scheduled drain job (launchd/cron or `/schedule` routine) so `valid_from` reflects real arrival time rather than a single bulk seed

## Tests

`tests/testthat/test-append-costs-from-staging.R` — 30 expectations across 8 scenarios:

| Scenario | Description |
|---|---|
| 1 | Empty staging → 0 rows, parquet not created |
| 2 | Single `cost_emitted` → 1 row with all v1 columns + correct `cost_id` |
| 3 | Dedup: existing `cost_id` in parquet not re-appended |
| 4 | Idempotent: second run over same staging → 0 new rows |
| 5 | Non-`cost_emitted` events ignored |
| 6 | Multi-day JSONL files combine correctly |
| 7a | All events missing required fields → warning + 0 rows |
| 7b | Mix of malformed + valid → bad skipped, good appended |

`devtools::test(filter = "append-costs")` → FAIL 0 | WARN 0 | SKIP 0 | PASS 30

## Test plan

- [ ] `pr-checks` workflow (privacy gate + R parse) passes on this PR
- [ ] All 30 append-costs tests still pass after merge

Part of #83 Phase A.<br><br>🤖 Generated with [Claude Code](https://claude.com/claude-code)