### PR TITLE
feat(ci): dispatchable self-review verify email

### DIFF
--- a/.github/workflows/self-review-email.yml
+++ b/.github/workflows/self-review-email.yml
@@ -1,0 +1,43 @@
+name: Self-Review Verify Email
+
+# Dispatched by the local self-review verify job (JohnGavin/llm#235) to email the
+# overnight self-review PASS/FAIL result. Reuses this repo's GMAIL_* secrets.
+on:
+  workflow_dispatch:
+    inputs:
+      result:
+        description: "PASS or FAIL"
+        required: true
+      count:
+        description: "self_review_findings_stage1 row count"
+        required: false
+        default: "?"
+      run_date:
+        description: "date of the verified run (YYYY-MM-DD)"
+        required: false
+        default: ""
+      details:
+        description: "extra detail line"
+        required: false
+        default: ""
+
+jobs:
+  send:
+    runs-on: ubuntu-latest
+    env:
+      GMAIL_USERNAME: ${{ secrets.GMAIL_USERNAME }}
+      GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+      SR_RESULT: ${{ github.event.inputs.result }}
+      SR_COUNT: ${{ github.event.inputs.count }}
+      SR_RUN_DATE: ${{ github.event.inputs.run_date }}
+      SR_DETAILS: ${{ github.event.inputs.details }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::blastula
+      - name: Send self-review email
+        run: Rscript inst/scripts/send_self_review_email.R

--- a/inst/scripts/send_self_review_email.R
+++ b/inst/scripts/send_self_review_email.R
@@ -1,0 +1,60 @@
+#!/usr/bin/env Rscript
+# Emails the overnight self-review PASS/FAIL result. Dispatched by the local
+# verify job (JohnGavin/llm#235) via workflow_dispatch. Reuses repo GMAIL_* secrets.
+# Mirrors the blastula send pattern in send_daily_email.R.
+suppressPackageStartupMessages(library(blastula))
+
+result   <- Sys.getenv("SR_RESULT", "UNKNOWN")
+count    <- Sys.getenv("SR_COUNT", "?")
+run_date <- Sys.getenv("SR_RUN_DATE", "")
+details  <- Sys.getenv("SR_DETAILS", "")
+if (!nzchar(run_date)) run_date <- format(Sys.Date())
+
+gmail_user <- Sys.getenv("GMAIL_USERNAME")
+gmail_pass <- Sys.getenv("GMAIL_APP_PASSWORD")
+
+emoji   <- if (identical(result, "PASS")) "✅" else "⚠️"
+subject <- sprintf("%s Overnight self-review: %s (%s)", emoji, result, run_date)
+
+details_line <- if (nzchar(details)) paste0("> ", details) else ""
+
+email_body <- paste0(
+  "## ", emoji, " Overnight self-review verification — ", run_date, "\n\n",
+  "**Result: ", result, "** &nbsp;|&nbsp; findings rows in `unified.duckdb`: **", count, "**\n\n",
+  details_line, "\n\n",
+  "### What this means\n",
+  "- **PASS** — last night's 02:30 self-review `--write` ran cleanly: wrote findings,",
+  " completed (`Done.`), no `duckdb: command not found`,",
+  " and `self_review_findings_stage1` has rows.\n",
+  "- **FAIL** — a regression. The overnight job did not produce findings as expected;",
+  " investigate.\n\n",
+  "### Where to look (on your machine)\n",
+  "- Stage-1 run log: `~/.claude/logs/self_review_stage1.log`\n",
+  "- Verify log (PASS/FAIL history): `~/.claude/logs/self_review_verify.log`\n",
+  "- Tracking issue: https://github.com/JohnGavin/llm/issues/235\n\n",
+  "_Sent by the self-review verify job (llm#235) via llmtelemetry CI._"
+)
+
+if (nzchar(gmail_user) && nzchar(gmail_pass)) {
+  email <- compose_email(body = md(email_body))
+  smtp_creds <- creds_envvar(
+    user = gmail_user,
+    pass_envvar = "GMAIL_APP_PASSWORD",
+    host = "smtp.gmail.com",
+    port = 465,
+    use_ssl = TRUE
+  )
+  tryCatch({
+    smtp_send(
+      email = email, to = gmail_user, from = gmail_user,
+      subject = subject, credentials = smtp_creds
+    )
+    message("Self-review email sent: ", subject)
+  }, error = function(e) {
+    message("ERROR: SMTP send failed: ", e$message)
+    cat(email_body)
+  })
+} else {
+  message("GMAIL creds not set; printing body:")
+  cat(email_body)
+}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/self-review-email.yml`: a `workflow_dispatch` workflow that emails the overnight self-review PASS/FAIL result using the repo's existing `GMAIL_USERNAME` / `GMAIL_APP_PASSWORD` secrets.
- Adds `inst/scripts/send_self_review_email.R`: mirrors the `blastula` smtp_send pattern from `send_daily_email.R`. When GMAIL creds are absent (dry-run / local) it prints the body and exits 0.
- Triggered by the local verify job in [JohnGavin/llm#235](https://github.com/JohnGavin/llm/issues/235) after it checks that the overnight `--write` stage-1 self-review completed and wrote rows to `self_review_findings_stage1` in `unified.duckdb`.

## Inputs

| input | required | description |
|---|---|---|
| `result` | yes | `PASS` or `FAIL` |
| `count` | no | `self_review_findings_stage1` row count |
| `run_date` | no | date of verified run (YYYY-MM-DD); defaults to today |
| `details` | no | extra detail line shown as a blockquote |

## Test plan

- [x] YAML parse: `python3 -c "import yaml; yaml.safe_load(open(...))"` → `YAML OK`
- [x] R parse: `Rscript -e 'invisible(parse(...))'` → `R parse OK`
- [x] Dry-run (creds unset): prints PASS body with log paths and issue link, exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)