### PR TITLE
fix(telemetry): HF git push auth (username=repo-owner, trim token)

### DIFF
--- a/R/hf_push.R
+++ b/R/hf_push.R
@@ -168,10 +168,11 @@ hf_push_telemetry <- function(
 
   clone_dir <- file.path(workdir, "repo")
 
-  # Build the GIT_ASKPASS helper: a transient shell script that cats the token.
+  # Build the GIT_ASKPASS helper: a transient prompt-aware shell script.
+  # Username prompt → repo owner; Password prompt → token file.
   # The helper is deleted immediately after git clone completes so the file's
   # lifetime is minimised.  NEVER embed the token in the clone URL.
-  askpass_script <- .hf_make_askpass(resolved_token, workdir)
+  askpass_script <- .hf_make_askpass(resolved_token, workdir, hf_repo)
   on.exit(
     if (file.exists(askpass_script)) file.remove(askpass_script),
     add = TRUE
@@ -235,7 +236,7 @@ hf_push_telemetry <- function(
           stdout = FALSE, stderr = FALSE)
 
   # Re-create GIT_ASKPASS for push (helper was deleted after clone)
-  askpass_script2 <- .hf_make_askpass(resolved_token, workdir)
+  askpass_script2 <- .hf_make_askpass(resolved_token, workdir, hf_repo)
   on.exit(
     if (file.exists(askpass_script2)) file.remove(askpass_script2),
     add = TRUE
@@ -352,10 +353,14 @@ hf_push_telemetry <- function(
   env_token <- Sys.getenv("HF_TOKEN", unset = "")
   if (nzchar(env_token)) {
     transient_path <- file.path(workdir, ".hf_token_ci")
-    writeLines(env_token, con = transient_path)
+    # Trim trailing whitespace/newlines — gh secret set from a file can
+    # include a trailing newline that would corrupt git auth.
+    env_token_trimmed <- trimws(env_token, which = "right")
+    writeLines(env_token_trimmed, con = transient_path)
     Sys.chmod(transient_path, mode = "0600")
-    # Clear the env_token string from the local scope immediately
+    # Clear the local string immediately
     env_token <- NULL
+    env_token_trimmed <- NULL
     return(transient_path)
   }
   # Neither source available — abort with a clear message
@@ -369,22 +374,41 @@ hf_push_telemetry <- function(
 
 #' Create a transient GIT_ASKPASS helper script.
 #'
-#' Writes a minimal shell script that `cat`s the HuggingFace token file.
-#' The caller is responsible for deleting the script after use.
+#' Writes a minimal shell script that is prompt-aware: when git invokes
+#' `$GIT_ASKPASS "<prompt>"`, the helper checks the first word of the prompt:
+#' - `Username*` → prints the HF repo owner (the part before `/` in `hf_repo`)
+#'   using `printf` without a trailing newline.
+#' - Anything else (the Password prompt) → `cat`s the token file.
 #'
+#' HuggingFace git-over-HTTPS requires username = the repo owner and
+#' password = the HF token.  Sending the token as the username causes
+#' "Invalid username or password".
+#'
+#' The caller is responsible for deleting the script after use.
 #' The token is NEVER read into R memory — it flows only from the token file
 #' to git's stdin via the helper process at clone/push time.
 #'
 #' @param token_path Character.  Path to the HF token file.
 #' @param workdir Character.  Directory in which to create the helper.
+#' @param hf_repo Character.  Repository identifier, e.g.
+#'   `"JohnGavin/llmtelemetry-metrics"`.  The owner (part before `/`) is
+#'   embedded in the helper as the git username.
 #' @return Character path to the helper script.
 #' @keywords internal
-.hf_make_askpass <- function(token_path, workdir) {
+.hf_make_askpass <- function(token_path, workdir, hf_repo) {
+  # Derive the repo owner: the substring before the first "/"
+  repo_owner <- sub("/.*$", "", hf_repo)
+
   helper_path <- file.path(workdir, "hf_askpass.sh")
   writeLines(
     c("#!/bin/sh",
-      # cat the token file; no variable interpolation — path is fixed at write time
-      paste0("cat ", shQuote(token_path))),
+      # Git passes the full prompt string as $1.
+      # "Username for 'https://...'" → return the repo owner (no trailing newline).
+      # "Password for 'https://...'" (or anything else) → cat the token file.
+      "case \"$1\" in",
+      paste0("  Username*) printf '%s' ", shQuote(repo_owner), " ;;"),
+      paste0("  *)         cat ", shQuote(token_path), " ;;"),
+      "esac"),
     con = helper_path
   )
   Sys.chmod(helper_path, mode = "0700")

--- a/tests/testthat/test-hf-push.R
+++ b/tests/testthat/test-hf-push.R
@@ -298,3 +298,77 @@ test_that("hf_push_telemetry() dry-run succeeds with HF_TOKEN env var (no local 
   expect_true(result$dry_run)
   expect_equal(result$sessions_rows, 2L)
 })
+
+# ---------------------------------------------------------------------------
+# Test 6: GIT_ASKPASS helper is prompt-aware (username vs password)
+# ---------------------------------------------------------------------------
+
+test_that(".hf_make_askpass() returns repo owner for Username prompt", {
+  tmpdir     <- withr::local_tempdir()
+  token_file <- file.path(tmpdir, "token")
+  writeLines("fake-token-value", token_file)
+
+  script <- llmtelemetry:::.hf_make_askpass(
+    token_path = token_file,
+    workdir    = tmpdir,
+    hf_repo    = "JohnGavin/llmtelemetry-metrics"
+  )
+
+  # Invoke the helper with a Username prompt (as git does)
+  result <- system2(script, args = "Username for 'https://huggingface.co'",
+                    stdout = TRUE, stderr = FALSE)
+  expect_equal(result, "JohnGavin")
+})
+
+test_that(".hf_make_askpass() returns token content for Password prompt", {
+  tmpdir     <- withr::local_tempdir()
+  token_file <- file.path(tmpdir, "token")
+  # Write token without trailing newline (trimmed, as CI path produces)
+  writeLines("fake-token-value", token_file)
+
+  script <- llmtelemetry:::.hf_make_askpass(
+    token_path = token_file,
+    workdir    = tmpdir,
+    hf_repo    = "JohnGavin/llmtelemetry-metrics"
+  )
+
+  # Invoke with a Password prompt
+  result <- system2(script, args = "Password for 'https://huggingface.co'",
+                    stdout = TRUE, stderr = FALSE)
+  # writeLines adds a newline; system2 stdout strips trailing newlines per line
+  expect_equal(result, "fake-token-value")
+})
+
+test_that(".hf_make_askpass() extracts correct owner from multi-part repo names", {
+  tmpdir     <- withr::local_tempdir()
+  token_file <- file.path(tmpdir, "token")
+  writeLines("tok", token_file)
+
+  script <- llmtelemetry:::.hf_make_askpass(
+    token_path = token_file,
+    workdir    = tmpdir,
+    hf_repo    = "MyOrg/my-dataset-repo"
+  )
+
+  result <- system2(script, args = "Username for 'https://huggingface.co'",
+                    stdout = TRUE, stderr = FALSE)
+  expect_equal(result, "MyOrg")
+})
+
+# ---------------------------------------------------------------------------
+# Test 7: Token trimming — trailing whitespace stripped before writing
+# ---------------------------------------------------------------------------
+
+test_that(".hf_resolve_token_path() trims trailing newline from HF_TOKEN env var", {
+  tmpdir      <- withr::local_tempdir()
+  absent_path <- file.path(tmpdir, "nonexistent_token")
+
+  # Simulate a token with a trailing newline (common from gh secret set)
+  withr::with_envvar(c(HF_TOKEN = "my-real-token\n"), {
+    result <- llmtelemetry:::.hf_resolve_token_path(absent_path, tmpdir)
+
+    written <- readLines(result, warn = FALSE)
+    # Must be stripped — no empty line at end
+    expect_equal(written, "my-real-token")
+  })
+})


### PR DESCRIPTION
## Root cause

`git push` to HuggingFace HTTPS failed with "Invalid username or password" because `.hf_make_askpass()` generated a helper that `cat`-ed the token for ALL git credential prompts — including the `Username for '...'` prompt. HuggingFace git-over-HTTPS requires **username = repo owner** and **password = HF token**. Sending the token as the username is rejected.

## Fix

**Fix 1 — Prompt-aware `GIT_ASKPASS` helper (`.hf_make_askpass()`):**
- Now accepts `hf_repo` arg (e.g. `"JohnGavin/llmtelemetry-metrics"`).
- Derives repo owner via `sub("/.*$", "", hf_repo)`.
- Generated shell script uses `case "$1" in Username*) ... ;; *) ... ;; esac`:
  - `Username*` prompt → `printf '%s' <repo-owner>` (no trailing newline)
  - `Password*` prompt → `cat <token-file>`
- Both `.hf_make_askpass()` call sites (clone + push) updated to pass `hf_repo`.

**Fix 2 — Defensive token trim (`.hf_resolve_token_path()`):**
- `trimws(env_token, which = "right")` applied before writing the transient token file.
- A trailing newline from `gh secret set` would otherwise corrupt the Password credential.

## Tests

Added tests 6 and 7 to `test-hf-push.R`:
- Askpass returns repo owner string for `Username` prompt.
- Askpass returns token content for `Password` prompt.
- Owner extraction works for multi-part repo names (`MyOrg/my-dataset-repo`).
- Token trimming removes trailing `\n` from env-var token.

All 24 hf-push tests pass (`FAIL 0 | WARN 0 | SKIP 0 | PASS 24`).
Dry-run verified: Privacy guard PASS, no network call.

References the failed run of #83 Phase F.

ORCHESTRATOR REVIEW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)