### PR TITLE
fix(telemetry): strip trailing newline from HF token in git auth

### DIFF
--- a/R/hf_push.R
+++ b/R/hf_push.R
@@ -353,10 +353,15 @@ hf_push_telemetry <- function(
   env_token <- Sys.getenv("HF_TOKEN", unset = "")
   if (nzchar(env_token)) {
     transient_path <- file.path(workdir, ".hf_token_ci")
-    # Trim trailing whitespace/newlines — gh secret set from a file can
-    # include a trailing newline that would corrupt git auth.
-    env_token_trimmed <- trimws(env_token, which = "right")
-    writeLines(env_token_trimmed, con = transient_path)
+    # Trim ALL trailing/leading whitespace and strip internal CR/LF.
+    # gh secret set from a file can include a trailing newline that corrupts
+    # git auth ("password authentication no longer supported" from HuggingFace
+    # means git sent "hf_xxx\n" as the password — the classic trailing-newline
+    # symptom).  Use cat(..., sep = "") (NOT writeLines, which appends "\n")
+    # so the file on disk contains exactly the token bytes with no newline.
+    env_token_trimmed <- trimws(env_token, which = "both")
+    env_token_trimmed <- gsub("[\r\n]", "", env_token_trimmed)
+    cat(env_token_trimmed, file = transient_path, sep = "")
     Sys.chmod(transient_path, mode = "0600")
     # Clear the local string immediately
     env_token <- NULL
@@ -378,7 +383,11 @@ hf_push_telemetry <- function(
 #' `$GIT_ASKPASS "<prompt>"`, the helper checks the first word of the prompt:
 #' - `Username*` → prints the HF repo owner (the part before `/` in `hf_repo`)
 #'   using `printf` without a trailing newline.
-#' - Anything else (the Password prompt) → `cat`s the token file.
+#' - Anything else (the Password prompt) → emits the token via
+#'   `printf '%s' "$(cat <file>)"`.  Command substitution strips trailing
+#'   newlines from the file; `printf %s` adds none.  This ensures git never
+#'   receives `hf_xxx\n` as the password even if the token file on disk
+#'   (e.g. `~/.cache/huggingface/token`) carries a trailing newline.
 #'
 #' HuggingFace git-over-HTTPS requires username = the repo owner and
 #' password = the HF token.  Sending the token as the username causes
@@ -407,7 +416,12 @@ hf_push_telemetry <- function(
       # "Password for 'https://...'" (or anything else) → cat the token file.
       "case \"$1\" in",
       paste0("  Username*) printf '%s' ", shQuote(repo_owner), " ;;"),
-      paste0("  *)         cat ", shQuote(token_path), " ;;"),
+      # Use printf '%s' "$(cat ...)" rather than plain cat: command substitution
+      # strips any trailing newlines from the file, and printf %s adds none.
+      # This is the belt-and-braces guard so even if the token file on disk
+      # somehow carries a trailing newline (e.g. the local ~/.cache/huggingface/token
+      # written by huggingface-cli), git never receives "hf_xxx\n" as the password.
+      paste0("  *)         printf '%s' \"$(cat ", shQuote(token_path), ")\" ;;"),
       "esac"),
     con = helper_path
   )

--- a/tests/testthat/test-hf-push.R
+++ b/tests/testthat/test-hf-push.R
@@ -259,9 +259,14 @@ test_that(".hf_resolve_token_path() falls back to HF_TOKEN env var when file abs
     perm_bits <- bitwAnd(as.integer(info$mode), 511L)  # 511L = 0777 octal
     expect_equal(perm_bits, 384L)                       # 384L = 0600 octal
 
-    # Content must equal what was in the env var (token written to file)
-    written <- readLines(result, warn = FALSE)
-    expect_equal(written, "ci-test-token-value")
+    # Content must equal what was in the env var (token written to file).
+    # Use readBin to verify the file truly has no trailing newline byte on disk
+    # (readLines would strip it silently and mask the bug).
+    raw_bytes <- readBin(result, what = "raw", n = 200L)
+    file_str  <- rawToChar(raw_bytes)
+    expect_false(grepl("[\r\n]", file_str),
+      info = "Token file must contain no newline bytes")
+    expect_equal(file_str, "ci-test-token-value")
   })
 })
 
@@ -367,8 +372,41 @@ test_that(".hf_resolve_token_path() trims trailing newline from HF_TOKEN env var
   withr::with_envvar(c(HF_TOKEN = "my-real-token\n"), {
     result <- llmtelemetry:::.hf_resolve_token_path(absent_path, tmpdir)
 
-    written <- readLines(result, warn = FALSE)
-    # Must be stripped — no empty line at end
-    expect_equal(written, "my-real-token")
+    # readLines strips the newline when reading; use readBin to confirm the
+    # file truly contains no trailing newline byte on disk.
+    raw_bytes <- readBin(result, what = "raw", n = 100L)
+    file_str  <- rawToChar(raw_bytes)
+    # File must contain exactly the token with no trailing \n or \r
+    expect_false(grepl("[\r\n]", file_str),
+      info = "Token file must contain no newline bytes (root cause of HF auth failure)")
+    # Sanity: content equals the bare token
+    expect_equal(trimws(file_str, which = "both"), "my-real-token")
   })
+})
+
+test_that(".hf_make_askpass() Password branch strips trailing newline from token file", {
+  # Root cause regression test: if the token file on disk has a trailing
+  # newline (e.g. written by huggingface-cli or an old writeLines() call),
+  # the askpass helper must NOT pass it through to git.
+  # "remote: Password authentication in git is no longer supported" = HF
+  # received "hf_xxx\n" as the password — this test prevents recurrence.
+  tmpdir     <- withr::local_tempdir()
+  token_file <- file.path(tmpdir, "token_with_newline")
+
+  # Deliberately write a token file WITH a trailing newline
+  cat("hf_test_token_abc\n", file = token_file, sep = "")
+
+  script <- llmtelemetry:::.hf_make_askpass(
+    token_path = token_file,
+    workdir    = tmpdir,
+    hf_repo    = "JohnGavin/llmtelemetry-metrics"
+  )
+
+  # system2() stdout captures lines (strips trailing newline per line — that is
+  # fine). The key assertion is that stdout is exactly one element equal to the
+  # bare token, NOT two elements (bare token + empty string from the \n).
+  result <- system2(script, args = "Password for 'https://huggingface.co'",
+                    stdout = TRUE, stderr = FALSE)
+  expect_length(result, 1L)
+  expect_equal(result[[1L]], "hf_test_token_abc")
 })


### PR DESCRIPTION
## Root cause

HuggingFace's new error message — "remote: Password authentication in git is no longer supported. You must use a user access token..." — means HF received a token it didn't recognise as valid. The classic cause: git sent `hf_xxx\n` (token + trailing newline) as the password.

Two code paths contributed:

1. `.hf_resolve_token_path()` used `writeLines()` to write the env-var token to the transient file. `writeLines()` appends `\n`. So the file contained `hf_xxx\n`.
2. `.hf_make_askpass()` Password branch used `cat <token_path>`, which echoes the file content verbatim — including that trailing newline byte.

## Fixes applied

- **`.hf_resolve_token_path()`**: replace `writeLines()` with `cat(..., sep = "")` after `trimws(both)` + `gsub("[\r\n]", "", ...)`. The transient token file now contains exactly the token bytes, no newline.
- **`.hf_make_askpass()`**: change Password branch from `cat <file>` to `printf '%s' "$(cat <file>)"`. Command substitution strips trailing newlines; `printf %s` adds none. Belt-and-braces guard that also covers the local `~/.cache/huggingface/token` path (written by `huggingface-cli`, may carry a trailing newline).
- **Tests**: add `readBin` assertions (not `readLines`, which masks the bug) to confirm no newline bytes on disk; add a new regression test that writes a token file WITH a trailing newline, invokes the askpass Password branch, and asserts stdout is exactly one element equal to the bare token.

Third fix in the Phase F push-auth chain. ORCHESTRATOR REVIEW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)