### PR TITLE
fix(telemetry): prefer hf over deprecated huggingface-cli

### DIFF
--- a/R/hf_push.R
+++ b/R/hf_push.R
@@ -8,7 +8,7 @@
 #' touching the network.  A live push only happens with `push = TRUE`.
 #'
 #' @section Authentication:
-#' The `huggingface-cli` command authenticates automatically from the
+#' The `hf` command authenticates automatically from the
 #' `HF_TOKEN` environment variable — no git credential helper, no token
 #' files, no ASKPASS script needed.  In CI, set the `HF_TOKEN` secret and
 #' pass it to the step via `env: HF_TOKEN: ${{ secrets.HF_TOKEN }}`.
@@ -16,12 +16,13 @@
 #' @section CLI invocation:
 #' The live push calls (after staging sanitised parquets to a temp dir):
 #' ```
-#' huggingface-cli upload <repo_id> <staging_dir> . \
+#' hf upload <repo_id> <staging_dir> . \
 #'   --repo-type dataset \
 #'   --commit-message "telemetry archive <date>"
 #' ```
-#' The CLI binary is resolved by `.hf_cli_binary()`: tries `huggingface-cli`
-#' first, then `hf` as a fallback (both are installed by `huggingface_hub`).
+#' The CLI binary is resolved by `.hf_cli_binary()`: tries `hf` first
+#' (`huggingface-cli` is deprecated and a non-functional no-op in current
+#' `huggingface_hub`), then `huggingface-cli` as fallback for older installs.
 #' Aborts if neither is found.
 #'
 #' @section Archive scope:
@@ -146,7 +147,7 @@ hf_push_telemetry <- function(
   .hf_write_parquet_duckdb(sessions_clean, sessions_out)
   .hf_write_parquet_duckdb(costs_clean,    costs_out)
 
-  # Resolve the CLI binary: huggingface-cli (preferred) or hf (alias)
+  # Resolve the CLI binary: hf (preferred, current) or huggingface-cli (legacy fallback)
   cli_bin <- .hf_cli_binary()
 
   commit_msg <- sprintf(
@@ -204,16 +205,17 @@ hf_push_telemetry <- function(
 # Internal helpers
 # ---------------------------------------------------------------------------
 
-#' Resolve the huggingface-cli binary.
+#' Resolve the HuggingFace CLI binary.
 #'
-#' Tries `huggingface-cli` first (the canonical name installed by
-#' `pip install huggingface_hub`), then `hf` as a fallback alias.
+#' Tries `hf` first (the current binary name in `huggingface_hub` >= 0.24;
+#' `huggingface-cli` is deprecated and a non-functional no-op in that version).
+#' Falls back to `huggingface-cli` only when `hf` is absent (older installs).
 #' Aborts with a clear message if neither is found on PATH.
 #'
 #' @return Character name of the binary to pass to [system2()].
 #' @keywords internal
 .hf_cli_binary <- function() {
-  for (bin in c("huggingface-cli", "hf")) {
+  for (bin in c("hf", "huggingface-cli")) {
     # Sys.which() is a pure-R lookup — no subprocess, respects the current PATH,
     # and returns "" when the binary is absent (never throws).
     found <- Sys.which(bin)
@@ -226,7 +228,7 @@ hf_push_telemetry <- function(
       "x" = "HuggingFace CLI not found on PATH.",
       "i" = paste0(
         "Install it with: {.code pip install --upgrade huggingface_hub}. ",
-        "Ensure the resulting {.code huggingface-cli} (or {.code hf}) is on PATH."
+        "Ensure the resulting {.code hf} (or {.code huggingface-cli}) is on PATH."
       )
     )
   )

--- a/tests/testthat/test-hf-push.R
+++ b/tests/testthat/test-hf-push.R
@@ -235,14 +235,28 @@ test_that("hf_push_telemetry() errors when sessions parquet does not exist", {
 # Test 5: .hf_cli_binary() resolves the correct binary
 # ---------------------------------------------------------------------------
 
-test_that(".hf_cli_binary() returns a non-empty string for a known-available binary", {
-  # We can't guarantee huggingface-cli is installed in the test environment,
-  # but we CAN verify the function returns something when the binary exists.
-  # Mock by shimming PATH with a fake binary.
+test_that(".hf_cli_binary() prefers 'hf' over 'huggingface-cli' when both present", {
+  # Both binaries on PATH — 'hf' must win (huggingface-cli is deprecated no-op)
   shim_dir <- withr::local_tempdir()
-  fake_bin <- file.path(shim_dir, "huggingface-cli")
-  writeLines("#!/bin/sh\necho 'fake-hf-cli'", fake_bin)
-  Sys.chmod(fake_bin, mode = "0755")
+  fake_hf  <- file.path(shim_dir, "hf")
+  fake_old <- file.path(shim_dir, "huggingface-cli")
+  writeLines("#!/bin/sh\necho 'fake-hf'", fake_hf)
+  writeLines("#!/bin/sh\necho 'fake-hf-cli'", fake_old)
+  Sys.chmod(fake_hf,  mode = "0755")
+  Sys.chmod(fake_old, mode = "0755")
+
+  withr::with_envvar(c(PATH = paste0(shim_dir, ":", Sys.getenv("PATH"))), {
+    result <- llmtelemetry:::.hf_cli_binary()
+    expect_equal(result, "hf")
+  })
+})
+
+test_that(".hf_cli_binary() falls back to 'huggingface-cli' when hf absent", {
+  # Only legacy binary present — older huggingface_hub installs
+  shim_dir <- withr::local_tempdir()
+  fake_old <- file.path(shim_dir, "huggingface-cli")
+  writeLines("#!/bin/sh\necho 'fake-hf-cli'", fake_old)
+  Sys.chmod(fake_old, mode = "0755")
 
   withr::with_envvar(c(PATH = paste0(shim_dir, ":", Sys.getenv("PATH"))), {
     result <- llmtelemetry:::.hf_cli_binary()
@@ -250,14 +264,12 @@ test_that(".hf_cli_binary() returns a non-empty string for a known-available bin
   })
 })
 
-test_that(".hf_cli_binary() falls back to 'hf' when huggingface-cli absent", {
+test_that(".hf_cli_binary() returns 'hf' when only hf present", {
   shim_dir <- withr::local_tempdir()
-  # Only provide 'hf', not 'huggingface-cli'
-  fake_hf <- file.path(shim_dir, "hf")
+  fake_hf  <- file.path(shim_dir, "hf")
   writeLines("#!/bin/sh\necho 'fake-hf'", fake_hf)
   Sys.chmod(fake_hf, mode = "0755")
 
-  # Override PATH so 'which huggingface-cli' fails but 'which hf' succeeds
   withr::with_envvar(c(PATH = paste0(shim_dir, ":", Sys.getenv("PATH"))), {
     result <- llmtelemetry:::.hf_cli_binary()
     expect_equal(result, "hf")
@@ -265,7 +277,7 @@ test_that(".hf_cli_binary() falls back to 'hf' when huggingface-cli absent", {
 })
 
 test_that(".hf_cli_binary() aborts when neither binary is found", {
-  # Use a PATH with no huggingface-cli or hf
+  # Use a PATH with no hf or huggingface-cli
   empty_dir <- withr::local_tempdir()
   withr::with_envvar(c(PATH = empty_dir), {
     expect_error(
@@ -279,15 +291,15 @@ test_that(".hf_cli_binary() aborts when neither binary is found", {
 # Test 6: Live-push path invokes huggingface-cli with correct args (mocked)
 # ---------------------------------------------------------------------------
 
-test_that("hf_push_telemetry() push=TRUE calls huggingface-cli upload with correct args", {
-  # Strategy: shim the PATH with a fake huggingface-cli that captures its
-  # argv to a temp file and exits 0, so hf_push_telemetry(push=TRUE) runs
-  # without any network call.
+test_that("hf_push_telemetry() push=TRUE calls hf upload with correct args", {
+  # Strategy: shim the PATH with a fake 'hf' that captures its argv to a
+  # temp file and exits 0, so hf_push_telemetry(push=TRUE) runs without
+  # any network call.  Use 'hf' (the preferred binary) not 'huggingface-cli'.
 
   shim_dir <- withr::local_tempdir()
   argv_log <- file.path(shim_dir, "argv.txt")
 
-  fake_cli <- file.path(shim_dir, "huggingface-cli")
+  fake_cli <- file.path(shim_dir, "hf")
   writeLines(
     c("#!/bin/sh",
       paste0("echo \"$@\" >> '", argv_log, "'"),
@@ -330,9 +342,9 @@ test_that("hf_push_telemetry() push=TRUE calls huggingface-cli upload with corre
 })
 
 test_that("hf_push_telemetry() push=TRUE aborts when CLI exits non-zero", {
-  # Shim that exits 1 (simulates upload failure)
+  # Shim 'hf' that exits 1 (simulates upload failure)
   shim_dir <- withr::local_tempdir()
-  fake_cli <- file.path(shim_dir, "huggingface-cli")
+  fake_cli <- file.path(shim_dir, "hf")
   writeLines(
     c("#!/bin/sh",
       "echo 'simulated upload error' >&2",


### PR DESCRIPTION
## Summary

- `huggingface-cli` is deprecated and now a non-functional no-op in current `huggingface_hub`; CI was failing with: `Warning: huggingface-cli is deprecated and no longer works. Use hf`
- `.hf_cli_binary()` now tries `hf` first, falls back to `huggingface-cli` only for older installs — reverse of the previous order
- Tests updated: new test asserts `hf` wins when both binaries are on PATH; live-push shims updated from `huggingface-cli` to `hf`

Final fix in the HF push chain — auth + upload now reached; only the binary name was wrong.

## Test plan

- [ ] `devtools::test(filter="hf-push")` → 27 PASS, 0 FAIL
- [ ] Dry-run `push_telemetry_to_huggingface.R` → "Privacy guard: PASS", no network call
- [ ] CI run reaches upload step without the deprecated-binary warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)