### PR TITLE
fix(ci): normalise HF token + hf auth login before upload

### DIFF
--- a/.github/workflows/hf-archive.yaml
+++ b/.github/workflows/hf-archive.yaml
@@ -86,5 +86,5 @@ jobs:
           fi
           HF_TOKEN_CLEAN="$(printf '%s' "$HF_TOKEN" | tr -d '[:space:]')"
           export HF_TOKEN="$HF_TOKEN_CLEAN"
-          huggingface-cli login --token "$HF_TOKEN_CLEAN"
+          hf auth login --token "$HF_TOKEN_CLEAN"
           Rscript inst/scripts/push_telemetry_to_huggingface.R --push

--- a/.github/workflows/hf-archive.yaml
+++ b/.github/workflows/hf-archive.yaml
@@ -68,8 +68,23 @@ jobs:
       # Privacy guard: if any confidential row is detected the script exits
       # non-zero → CI fails closed.  Do NOT suppress this failure.
       # huggingface-cli reads HF_TOKEN from the environment automatically.
+      #
+      # Token normalisation: strip all whitespace from the secret (HF tokens
+      # are "hf_" + alphanumerics with no internal spaces; trailing newlines
+      # from paste-at-rest are the most common source of 401 errors).
+      # Explicit "hf auth login" validates the token early and emits a clear
+      # error if the token value is invalid, rather than a cryptic 401 buried
+      # inside the R upload call.
       # -----------------------------------------------------------------------
       - name: Push sanitised telemetry archive to HuggingFace
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: Rscript inst/scripts/push_telemetry_to_huggingface.R --push
+        run: |
+          if [ -z "$HF_TOKEN" ]; then
+            echo "::error::HF_TOKEN is empty in the push step — aborting."
+            exit 1
+          fi
+          HF_TOKEN_CLEAN="$(printf '%s' "$HF_TOKEN" | tr -d '[:space:]')"
+          export HF_TOKEN="$HF_TOKEN_CLEAN"
+          huggingface-cli login --token "$HF_TOKEN_CLEAN"
+          Rscript inst/scripts/push_telemetry_to_huggingface.R --push


### PR DESCRIPTION
## Summary

- 401 on token: strip all whitespace from `$HF_TOKEN` with `tr -d '[:space:]'` (HF tokens are `hf_` + alphanumerics, no internal spaces; trailing newlines captured at paste time are the most common 401 cause)
- Add explicit `huggingface-cli login --token "$HF_TOKEN_CLEAN"` before the R upload step — fails loudly and clearly if the token value itself is invalid
- Re-export the cleaned token as `HF_TOKEN` so the R step's `hf upload` also sees a whitespace-free value
- If 401 persists after this PR, the token value itself is invalid — user should re-issue at https://huggingface.co/settings/tokens

## Test plan

- [ ] YAML parsed successfully by `yaml::read_yaml()` (verified locally)
- [ ] Only `.github/workflows/hf-archive.yaml` changed (verified via `git diff`)
- [ ] Trigger `workflow_dispatch` after merge and confirm `huggingface-cli login` step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)