### PR TITLE
feat(dashboard): roborev agent pass-rate panel (#146 Q10)

### DIFF
--- a/inst/extdata/roborev_agent_perf.json
+++ b/inst/extdata/roborev_agent_perf.json
@@ -1,0 +1,1 @@
+{"agents":[{"agent":"claude-code","n_runs":634,"pass_count":159,"fail_count":431,"error_count":25,"pass_rate":0.2508},{"agent":"codex","n_runs":4055,"pass_count":903,"fail_count":2970,"error_count":149,"pass_rate":0.2227},{"agent":"gemini","n_runs":9,"pass_count":1,"fail_count":0,"error_count":8,"pass_rate":0.1111}],"generated_at":"2026-05-25T19:26:48Z"}

--- a/inst/scripts/export_dashboard_data.R
+++ b/inst/scripts/export_dashboard_data.R
@@ -2306,6 +2306,125 @@ tryCatch({
   )
 })
 
+# --- 8f. Export roborev_agent_perf.json (#146 Q10) ----------------------------
+# Per-agent pass rate: pass_count / n_runs, total reviews, cost_per_review if available.
+# Source table: roborev_agent_performance (agent, model, n_runs, pass_count, fail_count,
+#   error_count, total_cost_usd).
+# Privacy: no repo/project column in this table — no clean_projects() needed.
+#   Agent names (codex, claude-code, gemini) are not confidential.
+# Guard: if table/columns missing, write empty-but-valid JSON and warn.
+cat("Exporting roborev_agent_perf.json...\n")
+tryCatch({
+  ap_src <- file.path(extdata, "roborev_agent_perf.json")
+  ap_dst <- file.path(out_dir, "roborev_agent_perf.json")
+
+  empty_ap <- list(agents = list(), generated_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ"))
+
+  if (file.exists(unified_db)) {
+    apcon <- dbConnect(duckdb(), dbdir = unified_db, read_only = TRUE)
+    on.exit(tryCatch(dbDisconnect(apcon, shutdown = TRUE), error = function(e) NULL),
+            add = TRUE)
+    ap_tbls <- dbListTables(apcon)
+
+    if ("roborev_agent_performance" %in% ap_tbls) {
+      ap_raw <- dbReadTable(apcon, "roborev_agent_performance") |> as_tibble()
+
+      # Validate required columns
+      req_cols <- c("agent", "n_runs", "pass_count", "fail_count")
+      missing_cols <- setdiff(req_cols, names(ap_raw))
+      if (length(missing_cols) > 0L) {
+        cat(sprintf("  -> roborev_agent_performance missing columns: %s; writing empty\n",
+                    paste(missing_cols, collapse = ", ")))
+        write_json(empty_ap, ap_src, auto_unbox = TRUE)
+      } else {
+        # Aggregate by agent (sum across dates)
+        has_cost <- "total_cost_usd" %in% names(ap_raw)
+
+        # Aggregate by agent across all dates.
+        # total_cost_usd is all-NA in the current data (cost not logged by roborev pipeline).
+        # Use any_nonzero_cost flag so sum(na.rm=TRUE)=0 is not mistaken for real zero cost.
+        any_nonzero_cost <- has_cost &&
+          any(!is.na(ap_raw$total_cost_usd) & ap_raw$total_cost_usd > 0, na.rm = TRUE)
+
+        ap_agg <- ap_raw |>
+          group_by(agent) |>
+          summarise(
+            n_runs      = sum(n_runs, na.rm = TRUE),
+            pass_count  = sum(pass_count, na.rm = TRUE),
+            fail_count  = sum(fail_count, na.rm = TRUE),
+            error_count = sum(error_count, na.rm = TRUE),
+            total_cost  = if (any_nonzero_cost) sum(total_cost_usd, na.rm = TRUE) else NA_real_,
+            .groups     = "drop"
+          ) |>
+          mutate(
+            pass_rate       = if_else(n_runs > 0L, round(pass_count / n_runs, 4), 0),
+            cost_per_review = if_else(
+              !is.na(total_cost) & n_runs > 0L,
+              round(total_cost / n_runs, 6),
+              NA_real_
+            )
+          ) |>
+          arrange(desc(pass_rate))
+
+        # Build output list
+        agent_list <- lapply(seq_len(nrow(ap_agg)), function(i) {
+          row <- ap_agg[i, , drop = FALSE]
+          out <- list(
+            agent       = row$agent,
+            n_runs      = as.integer(row$n_runs),
+            pass_count  = as.integer(row$pass_count),
+            fail_count  = as.integer(row$fail_count),
+            error_count = as.integer(row$error_count),
+            pass_rate   = row$pass_rate
+          )
+          if (!is.na(row$cost_per_review)) {
+            out$cost_per_review_usd <- row$cost_per_review
+            out$total_cost_usd      <- round(row$total_cost, 4)
+          }
+          out
+        })
+
+        ap_out <- list(
+          agents       = agent_list,
+          generated_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ")
+        )
+        write_json(ap_out, ap_src, auto_unbox = TRUE)
+        cat(sprintf(
+          "  -> roborev_agent_perf.json: %d agents, runs=%d, top pass-rate=%.1f%% (%s)\n",
+          nrow(ap_agg),
+          sum(ap_agg$n_runs),
+          max(ap_agg$pass_rate, na.rm = TRUE) * 100,
+          ap_agg$agent[which.max(ap_agg$pass_rate)]
+        ))
+        cat("  -> privacy: no repo column in roborev_agent_performance — no filtering needed\n")
+      }
+      tryCatch(dbDisconnect(apcon, shutdown = TRUE), error = function(e) NULL)
+    } else {
+      cat("  -> roborev_agent_performance not found; writing empty roborev_agent_perf.json\n")
+      write_json(empty_ap, ap_src, auto_unbox = TRUE)
+    }
+  } else {
+    cat("  -> unified.duckdb not found; will copy committed source\n")
+  }
+
+  # Always copy committed source to vignettes/data/
+  if (file.exists(ap_src)) {
+    file.copy(ap_src, ap_dst, overwrite = TRUE)
+    cat(sprintf("  -> copied roborev_agent_perf.json -> vignettes/data/ (%d bytes)\n",
+                file.info(ap_src)$size))
+  } else {
+    write_json(empty_ap, ap_dst, auto_unbox = TRUE)
+    cat("  -> no committed source; wrote empty placeholder to vignettes/data/\n")
+  }
+}, error = function(e) {
+  cat(sprintf("  -> roborev_agent_perf.json export error: %s\n", conditionMessage(e)))
+  write_json(
+    list(agents = list(), generated_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ")),
+    file.path(out_dir, "roborev_agent_perf.json"),
+    auto_unbox = TRUE
+  )
+})
+
 # --- 9. QA validation — fail early on empty critical data ---------------------
 cat("\n=== Data QA Validation ===\n")
 # ccusage_blocks is intentionally excluded from critical_files: the CI fallback

--- a/vignettes/dashboard_shinylive.qmd
+++ b/vignettes/dashboard_shinylive.qmd
@@ -42,6 +42,7 @@ format:
       - data/roborev_summary.json
       - data/roborev_by_repo.json
       - data/roborev_resolution.json
+      - data/roborev_agent_perf.json
       - data/v1/sessions.parquet
 filters:
   - shinylive
@@ -1467,6 +1468,25 @@ ui <- page_navbar(
               "The weekly trend shows resolved vs open reviews per week (based on created_at). ",
               "Data sourced from ~/.claude/logs/unified.duckdb roborev_review_lifecycle table; ",
               "refreshed on each local export run and committed to inst/extdata/ for CI serving.")
+          )
+        ),
+        layout_columns(col_widths = c(12),
+          card(
+            card_header("Agent Pass Rate (#146 Q10)"),
+            uiOutput("rv_agent_perf_chart"),
+            tags$table(class = "table table-sm table-dark mt-2 mb-0",
+              tags$thead(tags$tr(
+                tags$th("Agent"), tags$th("Reviews"), tags$th("Pass rate"),
+                tags$th("Pass"), tags$th("Fail"), tags$th("Error"),
+                tags$th("Cost/review")
+              )),
+              uiOutput("rv_agent_perf_table")
+            ),
+            card_footer(class = "text-muted small",
+              "Cleveland dot chart: pass rate (pass_count / n_runs) per review agent. ",
+              "Agents sourced from roborev_agent_performance in unified.duckdb (no repo column — no confidential filtering needed). ",
+              "Cost per review is shown only when total_cost_usd is available; NA values display as —. ",
+              "Data refreshed on each local export run and committed to inst/extdata/ for CI serving.")
           )
         )
       )
@@ -3471,6 +3491,9 @@ server <- function(input, output, session) {
   # roborev_resolution.json — resolution rate KPI + weekly trend (#146 Q5).
   # Contract: {overall:{total,resolved,open,resolution_rate}, weekly:[{week_start,resolved,open,total,resolution_rate},...]}
   roborev_resolution_raw <- load_json("roborev_resolution.json")
+  # roborev_agent_perf.json — per-agent pass rate + review counts (#146 Q10).
+  # Contract: {agents:[{agent,n_runs,pass_count,fail_count,error_count,pass_rate,...}], generated_at}
+  roborev_agent_perf_raw <- load_json("roborev_agent_perf.json")
 
   rv_pulse <- if (!is.null(roborev_summary_raw) && is.list(roborev_summary_raw)) {
     roborev_summary_raw$pulse
@@ -3645,6 +3668,107 @@ server <- function(input, output, session) {
       "Line chart: roborev resolved vs open reviews per week. ",
       "Green = resolved, red = open. Defaulting to last 3 months view."
     ))
+  })
+
+  # --- Agent Pass Rate panel (#146 Q10) ----------------------------------------
+  # Cleveland dot chart: pass rate per agent, sorted ascending (lowest at bottom).
+  # KPI table: agent | reviews | pass-rate | pass | fail | error | cost/review.
+  # Source: roborev_agent_perf.json {agents:[{agent,n_runs,pass_rate,...}]}.
+  safe_ap <- function(raw) {
+    if (is.null(raw) || !is.list(raw)) return(NULL)
+    agents <- raw$agents
+    if (is.null(agents) || length(agents) == 0L) return(NULL)
+    # Convert list-of-lists to data frame
+    do.call(rbind, lapply(agents, function(r) {
+      data.frame(
+        agent       = as.character(r$agent),
+        n_runs      = as.integer(r$n_runs),
+        pass_count  = as.integer(r$pass_count),
+        fail_count  = as.integer(r$fail_count),
+        error_count = as.integer(r$error_count),
+        pass_rate   = as.numeric(r$pass_rate),
+        cost_per_review = if (!is.null(r$cost_per_review_usd)) as.numeric(r$cost_per_review_usd) else NA_real_,
+        stringsAsFactors = FALSE
+      )
+    }))
+  }
+
+  output$rv_agent_perf_chart <- renderUI({
+    ap <- safe_ap(roborev_agent_perf_raw)
+    if (is.null(ap))
+      return(ec_empty("No agent performance data yet — roborev_agent_perf.json not deployed", h = "250px"))
+    # Sort ascending for Cleveland dot (lowest at bottom)
+    ap <- ap[order(ap$pass_rate, decreasing = FALSE), ]
+    n_agents   <- nrow(ap)
+    total_runs <- sum(ap$n_runs)
+    best_agent <- ap$agent[which.max(ap$pass_rate)]
+    best_rate  <- round(max(ap$pass_rate) * 100, 1)
+    ec(list(
+      tooltip = list(
+        trigger = "axis",
+        axisPointer = list(type = "shadow"),
+        formatter  = DT::JS(
+          "function(params) {",
+          "  var d = params[0];",
+          "  return d.name + '<br/>Pass rate: ' + (d.value * 100).toFixed(1) + '%';",
+          "}"
+        )
+      ),
+      grid = list(left = 110, containLabel = FALSE),
+      xAxis = list(
+        type = "value",
+        name = "Pass rate",
+        nameLocation = "middle", nameGap = 25,
+        min = 0, max = 1,
+        axisLabel = list(
+          color = "#ccc",
+          formatter = DT::JS("function(v){ return (v*100).toFixed(0)+'%'; }")
+        ),
+        nameTextStyle = list(color = "#ccc")
+      ),
+      yAxis = list(
+        type = "category",
+        data = I(ap$agent),
+        axisLabel = list(color = "#ccc", fontSize = 12)
+      ),
+      series = list(list(
+        type       = "scatter",
+        data       = I(ap$pass_rate),
+        symbolSize = 14,
+        itemStyle  = list(color = "#4ea8de")   # primary blue (accessibility palette)
+      ))
+    ), h = "250px",
+    aria_label = paste0(
+      "Cleveland dot chart: roborev review agent pass rate. ",
+      n_agents, " agents, ", total_runs, " total reviews. ",
+      "Best performing agent: ", best_agent, " at ", best_rate, "% pass rate. ",
+      "Data sourced from roborev_agent_performance table in unified.duckdb."
+    ))
+  })
+
+  output$rv_agent_perf_table <- renderUI({
+    ap <- safe_ap(roborev_agent_perf_raw)
+    if (is.null(ap)) {
+      return(tags$tbody(tags$tr(tags$td(colspan = "7", "No data yet"))))
+    }
+    # Sort descending by pass_rate for table (best first)
+    ap <- ap[order(ap$pass_rate, decreasing = TRUE), ]
+    fmt_cost <- function(x) {
+      if (is.na(x)) "—" else sprintf("$%.4f", x)
+    }
+    rows <- lapply(seq_len(nrow(ap)), function(i) {
+      r <- ap[i, , drop = FALSE]
+      tags$tr(
+        tags$td(r$agent),
+        tags$td(formatC(r$n_runs,      format = "d", big.mark = ",")),
+        tags$td(sprintf("%.1f%%", r$pass_rate * 100)),
+        tags$td(formatC(r$pass_count,  format = "d", big.mark = ",")),
+        tags$td(formatC(r$fail_count,  format = "d", big.mark = ",")),
+        tags$td(formatC(r$error_count, format = "d", big.mark = ",")),
+        tags$td(fmt_cost(r$cost_per_review))
+      )
+    })
+    tags$tbody(rows)
   })
 }
 


### PR DESCRIPTION
## Summary

- Adds **section 8f** to `export_dashboard_data.R`: reads `roborev_agent_performance` from `unified.duckdb`, aggregates pass_count/n_runs per agent, writes `roborev_agent_perf.json` to `inst/extdata/` and `vignettes/data/`
- Adds **Agent Pass Rate card** to the Reviews tab in `dashboard_shinylive.qmd`: Cleveland dot chart (pass rate per agent) + compact KPI table (agent | reviews | pass-rate | pass | fail | error | cost/review)
- Mirrors the Q5 resolution-rate pattern from #222 exactly (JSON-fetch via `load_json()`, dual-path copy, tryCatch guard, graceful degradation)

## Per-agent pass rates (computed 2026-05-25)

| Agent | Reviews | Pass rate |
|-------|---------|-----------|
| claude-code | 634 | 25.1% |
| codex | 4,055 | 22.3% |
| gemini | 9 | 11.1% |

## Privacy handling

`roborev_agent_performance` has no repo/project column — no `clean_projects()` filtering needed. Agent names (codex, claude-code, gemini) are not confidential. Noted in export log output.

## Cost/review

All `total_cost_usd` values are currently NULL in the source table. The `any_nonzero_cost` guard prevents `sum(NA, na.rm=TRUE) = 0` from being mis-reported as real zero cost. Cost columns are omitted from the JSON when not available; dashboard displays `—`.

## Test plan

- [ ] Verify `roborev_agent_perf.json` is written with 3 per-agent rows after running `export_dashboard_data.R` locally
- [ ] Verify dashboard panel renders with Cleveland dot chart and KPI table in the Reviews tab
- [ ] Verify graceful degradation when JSON not deployed (check empty message)
- [ ] Confirm CI passes (`deploy-dashboard.yaml`)

Addresses #146 Q10.

ORCHESTRATOR REVIEW — do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)