### PR TITLE
feat(codexbar): data layer — capture, sanitise, parse CodexBar usage/cost (#184)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ vignettes/_extensions/
 .roborev/
 inst/extdata/.codex_log_offset.txt
 inst/extdata/codex_log_offsets.json
+inst/extdata/codexbar_usage.json
+inst/extdata/codexbar_cost_daily.json

--- a/R/codexbar.R
+++ b/R/codexbar.R
@@ -1,0 +1,262 @@
+# CodexBar Usage and Cost Parsers
+# Parsers for CodexBar CLI JSON outputs (complementary to ccusage pipeline).
+# CodexBar CLI: /opt/homebrew/bin/codexbar v0.29.0
+# Do NOT replace ccusage — these are a second, complementary usage source.
+
+utils::globalVariables(c(
+  # parse_codexbar_usage
+  "provider", "source", "used_pct", "window_minutes", "resets_at",
+  "credits_remaining", "updated_at", "limit_window",
+  # parse_codexbar_cost
+  "date", "model", "cost", "total_tokens", "input_tokens", "output_tokens",
+  "cache_read_tokens", "cache_creation_tokens", "modelName",
+  "modelBreakdowns", "historyDays", "daily"
+))
+
+# ---------------------------------------------------------------------------
+# parse_codexbar_usage
+# ---------------------------------------------------------------------------
+
+#' Parse CodexBar usage JSON into a tidy tibble
+#'
+#' Reads the sanitised `codexbar_usage.json` file produced by
+#' `inst/scripts/sanitize_codexbar.R` (PII already stripped).  Returns one row
+#' per provider per limit window (primary / secondary / tertiary).  The raw
+#' `accountEmail`, `accountOrganization`, `identity`, and `loginMethod` fields
+#' are never present in the sanitised input; this function does not need to
+#' strip them.
+#'
+#' @param path Character(1).  Path to the sanitised `codexbar_usage.json`.
+#'   Defaults to `inst/extdata/codexbar_usage.json` resolved via [here::here()].
+#' @return A [tibble::tibble()] with columns:
+#'   \describe{
+#'     \item{provider}{character — provider name (e.g. "claude", "openai")}
+#'     \item{limit_window}{character — one of "primary", "secondary", "tertiary"}
+#'     \item{used_pct}{numeric — percentage of the window limit consumed (0-100)}
+#'     \item{window_minutes}{integer — length of the rate-limit window in minutes}
+#'     \item{resets_at}{character — ISO-8601 timestamp when the window resets}
+#'     \item{credits_remaining}{numeric — credits remaining (NA if not applicable)}
+#'     \item{source}{character — data source field from the raw payload}
+#'     \item{updated_at}{character — ISO-8601 timestamp of the last update}
+#'   }
+#'   Returns a zero-row tibble with those columns if the file does not exist or
+#'   contains no parseable records.
+#' @export
+#' @examples
+#' \dontrun{
+#' # Read from the default package location
+#' usage <- parse_codexbar_usage()
+#'
+#' # Read from an explicit path (e.g. a test fixture)
+#' usage <- parse_codexbar_usage("tests/testthat/fixtures/codexbar_usage_fixture.json")
+#' }
+parse_codexbar_usage <- function(
+    path = NULL
+) {
+  if (is.null(path)) {
+    candidates <- c(
+      file.path("inst", "extdata", "codexbar_usage.json"),
+      file.path("..", "inst", "extdata", "codexbar_usage.json")
+    )
+    if (requireNamespace("here", quietly = TRUE)) {
+      candidates <- c(here::here("inst", "extdata", "codexbar_usage.json"), candidates)
+    }
+    path <- Find(file.exists, candidates)
+  }
+
+  empty_tbl <- tibble::tibble(
+    provider          = character(),
+    limit_window      = character(),
+    used_pct          = numeric(),
+    window_minutes    = integer(),
+    resets_at         = character(),
+    credits_remaining = numeric(),
+    source            = character(),
+    updated_at        = character()
+  )
+
+  if (is.null(path) || !file.exists(path)) {
+    message("codexbar_usage.json not found: ", path %||% "<no path resolved>")
+    return(empty_tbl)
+  }
+
+  providers_list <- tryCatch(
+    jsonlite::fromJSON(path, simplifyVector = FALSE),
+    error = function(e) {
+      message("Failed to parse codexbar_usage.json: ", conditionMessage(e))
+      NULL
+    }
+  )
+  if (is.null(providers_list) || !is.list(providers_list)) return(empty_tbl)
+
+  window_names <- c("primary", "secondary", "tertiary")
+
+  rows <- purrr::map_dfr(providers_list, function(prov) {
+    pname   <- prov[["provider"]] %||% NA_character_
+    psrc    <- prov[["source"]]   %||% NA_character_
+    usage   <- prov[["usage"]]
+    credits <- prov[["credits"]]
+
+    credits_rem <- tryCatch(
+      as.numeric(credits[["remaining"]] %||% NA_real_),
+      error = function(e) NA_real_
+    )
+    upd_at <- tryCatch(
+      as.character(usage[["updatedAt"]] %||% NA_character_),
+      error = function(e) NA_character_
+    )
+
+    purrr::map_dfr(window_names, function(wname) {
+      win <- usage[[wname]]
+      if (is.null(win)) return(NULL)
+      tibble::tibble(
+        provider          = as.character(pname),
+        limit_window      = wname,
+        used_pct          = as.numeric(win[["usedPercent"]]    %||% NA_real_),
+        window_minutes    = as.integer(win[["windowMinutes"]]  %||% NA_integer_),
+        resets_at         = as.character(win[["resetsAt"]]     %||% NA_character_),
+        credits_remaining = credits_rem,
+        source            = as.character(psrc),
+        updated_at        = upd_at
+      )
+    })
+  })
+
+  if (is.null(rows) || nrow(rows) == 0L) return(empty_tbl)
+  rows
+}
+
+# ---------------------------------------------------------------------------
+# parse_codexbar_cost
+# ---------------------------------------------------------------------------
+
+#' Parse CodexBar cost JSON into a tidy per-provider per-date per-model tibble
+#'
+#' Reads the sanitised `codexbar_cost_daily.json` file produced by
+#' `inst/scripts/sanitize_codexbar.R`.  Expands the nested `modelBreakdowns`
+#' array so that each row represents one provider × date × model combination.
+#' Providers or dates with no `modelBreakdowns` entry are omitted (the top-level
+#' aggregate fields such as `last30DaysCostUSD` are not included here — use a
+#' separate rollup if needed).
+#'
+#' Note: CodexBar cost data uses `source:"local"` — it is a local estimate
+#' analogous to ccusage, not provider billing data.
+#'
+#' @param path Character(1).  Path to the sanitised `codexbar_cost_daily.json`.
+#'   Defaults to `inst/extdata/codexbar_cost_daily.json` resolved via
+#'   [here::here()].
+#' @return A [tibble::tibble()] with columns:
+#'   \describe{
+#'     \item{provider}{character — provider name}
+#'     \item{date}{character — ISO-8601 date string (YYYY-MM-DD)}
+#'     \item{model}{character — model name}
+#'     \item{cost}{numeric — estimated cost in USD for this model on this date}
+#'     \item{total_tokens}{numeric — total tokens consumed}
+#'     \item{input_tokens}{numeric — input tokens (prompt)}
+#'     \item{output_tokens}{numeric — output tokens (completion)}
+#'     \item{cache_read_tokens}{numeric — cache-read tokens (0 if provider does not report)}
+#'     \item{cache_creation_tokens}{numeric — cache-creation tokens (0 if not reported)}
+#'   }
+#'   Returns a zero-row tibble with those columns if the file does not exist or
+#'   contains no parseable records.
+#' @export
+#' @examples
+#' \dontrun{
+#' # Read from the default package location
+#' cost <- parse_codexbar_cost()
+#'
+#' # Read from a test fixture
+#' cost <- parse_codexbar_cost("tests/testthat/fixtures/codexbar_cost_fixture.json")
+#' }
+parse_codexbar_cost <- function(
+    path = NULL
+) {
+  if (is.null(path)) {
+    candidates <- c(
+      file.path("inst", "extdata", "codexbar_cost_daily.json"),
+      file.path("..", "inst", "extdata", "codexbar_cost_daily.json")
+    )
+    if (requireNamespace("here", quietly = TRUE)) {
+      candidates <- c(
+        here::here("inst", "extdata", "codexbar_cost_daily.json"),
+        candidates
+      )
+    }
+    path <- Find(file.exists, candidates)
+  }
+
+  empty_tbl <- tibble::tibble(
+    provider              = character(),
+    date                  = character(),
+    model                 = character(),
+    cost                  = numeric(),
+    total_tokens          = numeric(),
+    input_tokens          = numeric(),
+    output_tokens         = numeric(),
+    cache_read_tokens     = numeric(),
+    cache_creation_tokens = numeric()
+  )
+
+  if (is.null(path) || !file.exists(path)) {
+    message("codexbar_cost_daily.json not found: ", path %||% "<no path resolved>")
+    return(empty_tbl)
+  }
+
+  providers_list <- tryCatch(
+    jsonlite::fromJSON(path, simplifyVector = FALSE),
+    error = function(e) {
+      message("Failed to parse codexbar_cost_daily.json: ", conditionMessage(e))
+      NULL
+    }
+  )
+  if (is.null(providers_list) || !is.list(providers_list)) return(empty_tbl)
+
+  rows <- purrr::map_dfr(providers_list, function(prov) {
+    pname <- prov[["provider"]] %||% NA_character_
+    daily <- prov[["daily"]]
+    if (is.null(daily) || !is.list(daily)) return(NULL)
+
+    purrr::map_dfr(daily, function(day_entry) {
+      d <- as.character(day_entry[["date"]] %||% NA_character_)
+      breakdowns <- day_entry[["modelBreakdowns"]]
+      if (is.null(breakdowns) || !is.list(breakdowns) || length(breakdowns) == 0L) {
+        return(NULL)
+      }
+      purrr::map_dfr(breakdowns, function(mb) {
+        tibble::tibble(
+          provider              = as.character(pname),
+          date                  = d,
+          model                 = as.character(mb[["modelName"]] %||% NA_character_),
+          cost                  = as.numeric(mb[["cost"]]          %||% 0),
+          total_tokens          = as.numeric(mb[["totalTokens"]]   %||% 0),
+          input_tokens          = as.numeric(
+            mb[["inputTokens"]]         %||%
+            mb[["input_tokens"]]        %||% 0
+          ),
+          output_tokens         = as.numeric(
+            mb[["outputTokens"]]        %||%
+            mb[["output_tokens"]]       %||% 0
+          ),
+          cache_read_tokens     = as.numeric(
+            mb[["cacheReadTokens"]]     %||%
+            mb[["cache_read_tokens"]]   %||% 0
+          ),
+          cache_creation_tokens = as.numeric(
+            mb[["cacheCreationTokens"]] %||%
+            mb[["cache_creation_tokens"]] %||% 0
+          )
+        )
+      })
+    })
+  })
+
+  if (is.null(rows) || nrow(rows) == 0L) return(empty_tbl)
+  rows
+}
+
+# ---------------------------------------------------------------------------
+# Internal helper — NULL-coalescing operator (not imported from rlang to keep
+# the dependency surface small).
+# ---------------------------------------------------------------------------
+
+`%||%` <- function(x, y) if (!is.null(x) && length(x) > 0L && !is.na(x[1L])) x else y

--- a/exec/refresh_codexbar.sh
+++ b/exec/refresh_codexbar.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# refresh_codexbar.sh — Capture CodexBar usage+cost JSON and sanitise.
+#
+# PURPOSE
+# -------
+# 1. Capture `codexbar usage --provider all --json` (may exit non-zero on
+#    single-provider auth failure; stdout JSON is still valid for other providers).
+# 2. Capture `codexbar cost --provider all --json`.
+# 3. Call sanitize_codexbar.R to strip PII and write the clean output files
+#    to inst/extdata/ (codexbar_usage.json and codexbar_cost_daily.json).
+#
+# DESIGN CONSTRAINTS
+# ------------------
+# - No git commit/push step here — handled separately downstream.
+# - Graceful skip when codexbar is not installed (CI / headless machines).
+# - `set -euo pipefail` is active but `codexbar usage` non-zero exit is
+#   handled explicitly (we tolerate it and still use stdout JSON).
+# - Log file: inst/logs/codexbar_refresh.log
+#
+# See also: inst/scripts/sanitize_codexbar.R
+#           R/codexbar.R (parsers)
+
+set -uo pipefail
+# NOTE: we do NOT use `set -e` unconditionally because `codexbar usage` can
+# legitimately exit non-zero (single-provider 401) while emitting valid JSON.
+# We handle the exit code explicitly below.
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+LOG_DIR="${PKG_ROOT}/inst/logs"
+LOG_FILE="${LOG_DIR}/codexbar_refresh.log"
+LOCK_FILE="/tmp/codexbar_refresh.lock"
+
+mkdir -p "${LOG_DIR}"
+
+log() {
+  printf '%s: %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" >> "${LOG_FILE}"
+}
+
+# ---------------------------------------------------------------------------
+# Lock (prevent concurrent runs)
+# ---------------------------------------------------------------------------
+if [ -f "${LOCK_FILE}" ]; then
+  existing_pid="$(cat "${LOCK_FILE}" 2>/dev/null || true)"
+  if [ -n "${existing_pid}" ] && kill -0 "${existing_pid}" 2>/dev/null; then
+    log "SKIP: another instance running (PID ${existing_pid})"
+    exit 0
+  fi
+fi
+printf '%d' "$$" > "${LOCK_FILE}"
+trap 'rm -f "${LOCK_FILE}"' EXIT
+
+# ---------------------------------------------------------------------------
+# Graceful skip when codexbar is unavailable (CI / headless)
+# ---------------------------------------------------------------------------
+if ! command -v codexbar > /dev/null 2>&1; then
+  log "SKIP: codexbar not found on PATH — skipping capture (CI/headless environment)"
+  exit 0
+fi
+
+log "Starting CodexBar refresh (codexbar $(codexbar --version 2>/dev/null || echo unknown))"
+
+# ---------------------------------------------------------------------------
+# Capture to temp files
+# ---------------------------------------------------------------------------
+TMP_USAGE="$(mktemp /tmp/codexbar_usage_raw.XXXXXX.json)"
+TMP_COST="$(mktemp  /tmp/codexbar_cost_raw.XXXXXX.json)"
+trap 'rm -f "${TMP_USAGE}" "${TMP_COST}"; rm -f "${LOCK_FILE}"' EXIT
+
+# --- usage (tolerate non-zero exit: single-provider 401 is expected) ---
+log "Capturing: codexbar usage --provider all --json"
+usage_exit=0
+codexbar usage --provider all --json > "${TMP_USAGE}" 2>> "${LOG_FILE}" || usage_exit=$?
+if [ "${usage_exit}" -ne 0 ]; then
+  log "WARNING: codexbar usage exited ${usage_exit} — proceeding with stdout JSON (partial providers OK)"
+fi
+
+# Verify we got at least some JSON (non-empty output)
+if [ ! -s "${TMP_USAGE}" ]; then
+  log "ERROR: codexbar usage produced no output — aborting"
+  exit 1
+fi
+
+# --- cost (should always succeed; abort on non-zero) ---
+log "Capturing: codexbar cost --provider all --json"
+if ! codexbar cost --provider all --json > "${TMP_COST}" 2>> "${LOG_FILE}"; then
+  log "ERROR: codexbar cost exited non-zero — aborting"
+  exit 1
+fi
+
+if [ ! -s "${TMP_COST}" ]; then
+  log "ERROR: codexbar cost produced no output — aborting"
+  exit 1
+fi
+
+log "Raw JSON captured (usage: $(wc -c < "${TMP_USAGE}") bytes, cost: $(wc -c < "${TMP_COST}") bytes)"
+
+# ---------------------------------------------------------------------------
+# Sanitise via R script (strips PII, writes inst/extdata/ outputs)
+# ---------------------------------------------------------------------------
+log "Running sanitize_codexbar.R"
+
+SANITIZE_SCRIPT="${PKG_ROOT}/inst/scripts/sanitize_codexbar.R"
+if [ ! -f "${SANITIZE_SCRIPT}" ]; then
+  log "ERROR: sanitize_codexbar.R not found at ${SANITIZE_SCRIPT}"
+  exit 1
+fi
+
+# Use Rscript directly; if not on PATH try the nix-shell for this project.
+if command -v Rscript > /dev/null 2>&1; then
+  if Rscript "${SANITIZE_SCRIPT}" "${TMP_USAGE}" "${TMP_COST}" >> "${LOG_FILE}" 2>&1; then
+    log "Sanitization complete"
+  else
+    log "ERROR: sanitize_codexbar.R failed — check ${LOG_FILE}"
+    exit 1
+  fi
+else
+  log "Rscript not on PATH — trying nix-shell"
+  NIX_SHELL_CMD="Rscript ${SANITIZE_SCRIPT} ${TMP_USAGE} ${TMP_COST}"
+  if nix-shell "${PKG_ROOT}/default.nix" --run "${NIX_SHELL_CMD}" >> "${LOG_FILE}" 2>&1; then
+    log "Sanitization complete (via nix-shell)"
+  else
+    log "ERROR: sanitize_codexbar.R failed via nix-shell — check ${LOG_FILE}"
+    exit 1
+  fi
+fi
+
+log "Done — inst/extdata/codexbar_usage.json and codexbar_cost_daily.json updated"

--- a/inst/scripts/sanitize_codexbar.R
+++ b/inst/scripts/sanitize_codexbar.R
@@ -1,0 +1,270 @@
+#!/usr/bin/env Rscript
+# sanitize_codexbar.R — Strip PII from CodexBar usage JSON before persistence.
+#
+# PURPOSE
+# -------
+# `codexbar usage --provider all --json` emits raw PII fields:
+#   accountEmail, accountOrganization, identity, loginMethod
+# These MUST be removed before writing to inst/extdata/ or committing to git.
+#
+# `codexbar cost --provider all --json` contains NO PII and is written as-is
+# after path-leak verification.
+#
+# USAGE
+# -----
+# Called by exec/refresh_codexbar.sh after capturing raw CLI output:
+#
+#   Rscript inst/scripts/sanitize_codexbar.R <raw_usage.json> <raw_cost.json>
+#
+# OUTPUT FILES (written to inst/extdata/)
+#   codexbar_usage.json      — sanitised usage (PII stripped)
+#   codexbar_cost_daily.json — cost data (no PII; verified clean)
+#
+# See also: tests/testthat/test-codexbar.R (regression gate for PII leaks)
+#           R/codexbar.R                   (parsers for these outputs)
+
+# Only load jsonlite if it is not already available (e.g. package namespace)
+if (!requireNamespace("jsonlite", quietly = TRUE)) {
+  stop("Package 'jsonlite' is required but not installed.")
+}
+if (!isTRUE(getOption("sanitize_codexbar_sourced_for_test"))) {
+  suppressPackageStartupMessages(library(jsonlite))
+}
+
+# ---------------------------------------------------------------------------
+# PII fields to strip from the usage payload
+# ---------------------------------------------------------------------------
+
+PII_USAGE_FIELDS <- c(
+  "accountEmail",
+  "accountOrganization",
+  "identity",
+  "loginMethod"
+)
+
+# Error message field: contains local filesystem paths in some provider error responses
+# (e.g. "Kilo CLI session not found at /Users/johngavin/...").  We strip the message
+# but preserve error.kind and error.code for diagnostics.
+PATH_LEAK_FIELDS_IN_ERROR <- c("message")
+
+# ---------------------------------------------------------------------------
+# SENSITIVE_VERIFY_PATTERNS — single source of truth (mirrors sanitize_ccusage_all.R)
+# ---------------------------------------------------------------------------
+# When running inside the package, llmtelemetry::sensitive_verify_patterns() is
+# available.  When running as a standalone Rscript (e.g. from exec/refresh_codexbar.sh),
+# we define an inline fallback that mirrors R/sensitive_patterns.R exactly.
+
+if (!exists("sensitive_verify_patterns", mode = "function")) {
+  sensitive_verify_patterns <- function() {
+    c(
+      "Users-johngavin",
+      "/Users/",
+      "/private/",
+      "/tmp/",
+      "/var/",
+      "-private-tmp-",
+      "-tmp-",
+      "-worktree-",
+      "worktree-agent-",
+      "johngavin"
+    )
+  }
+}
+
+SENSITIVE_VERIFY_PATTERNS <- sensitive_verify_patterns()
+
+# ---------------------------------------------------------------------------
+# strip_pii_from_usage_provider
+# ---------------------------------------------------------------------------
+
+#' Strip PII fields from a single provider usage object.
+#'
+#' Removes `accountEmail`, `accountOrganization`, `identity`, and `loginMethod`
+#' from the top-level `usage` block of a provider entry.  Provider-level fields
+#' (`provider`, `version`, `source`, `status`, `credits`) are preserved.
+#'
+#' @param prov list — a single provider object from the `codexbar usage --json` array
+#' @return list — the same object with PII fields removed from `usage`
+strip_pii_from_usage_provider <- function(prov) {
+  if (!is.list(prov)) return(prov)
+
+  # Strip from usage sub-object
+  if (is.list(prov[["usage"]])) {
+    for (field in PII_USAGE_FIELDS) {
+      prov[["usage"]][[field]] <- NULL
+    }
+  }
+
+  # Belt-and-suspenders: strip from top level in case a provider embeds them there
+  for (field in PII_USAGE_FIELDS) {
+    prov[[field]] <- NULL
+  }
+
+  # Strip error.message — some providers embed local filesystem paths in their
+  # error messages (e.g. "session not found at /Users/...").
+  if (is.list(prov[["error"]])) {
+    for (field in PATH_LEAK_FIELDS_IN_ERROR) {
+      prov[["error"]][[field]] <- NULL
+    }
+  }
+
+  prov
+}
+
+#' Sanitize the raw codexbar usage JSON array.
+#'
+#' @param providers_list list — parsed JSON array from `codexbar usage --provider all --json`
+#' @return list with elements:
+#'   \describe{
+#'     \item{sanitized}{list — the cleaned provider array}
+#'     \item{n_stripped}{integer — total PII field occurrences removed}
+#'   }
+sanitize_usage <- function(providers_list) {
+  if (!is.list(providers_list)) {
+    stop("providers_list must be a list (parsed JSON array)")
+  }
+
+  n_stripped <- 0L
+  sanitized <- lapply(providers_list, function(prov) {
+    before_fields <- c(
+      names(prov[["usage"]]),
+      names(prov)
+    )
+    cleaned <- strip_pii_from_usage_provider(prov)
+    after_fields <- c(
+      names(cleaned[["usage"]]),
+      names(cleaned)
+    )
+    n_stripped <<- n_stripped + sum(PII_USAGE_FIELDS %in% before_fields) -
+                               sum(PII_USAGE_FIELDS %in% after_fields)
+    cleaned
+  })
+
+  list(sanitized = sanitized, n_stripped = n_stripped)
+}
+
+# ---------------------------------------------------------------------------
+# verify_no_pii_leak — scan text for forbidden patterns
+# ---------------------------------------------------------------------------
+
+#' Verify that sanitised JSON text contains no forbidden path/PII patterns.
+#'
+#' @param text character(1) — JSON text to scan
+#' @param label character(1) — filename or label for error messages
+#' @return invisible(NULL) — stops on the first pattern hit
+verify_no_pii_leak <- function(text, label) {
+  # Check PII field names (belt-and-suspenders)
+  for (field in PII_USAGE_FIELDS) {
+    if (grepl(paste0('"', field, '"'), text, fixed = TRUE)) {
+      stop(sprintf(
+        "%s still contains PII field '%s' after sanitization — aborting",
+        label, field
+      ))
+    }
+  }
+
+  # Check path/username leaks
+  for (pat in SENSITIVE_VERIFY_PATTERNS) {
+    if (grepl(pat, text, perl = TRUE, fixed = FALSE)) {
+      stop(sprintf(
+        "%s contains forbidden path/PII pattern '%s' — aborting",
+        label, pat
+      ))
+    }
+  }
+
+  invisible(NULL)
+}
+
+# ---------------------------------------------------------------------------
+# Main — run when invoked as a script
+# ---------------------------------------------------------------------------
+
+if (!interactive() &&
+    !isTRUE(getOption("sanitize_codexbar_sourced_for_test"))) {
+
+  args <- commandArgs(trailingOnly = TRUE)
+  if (length(args) < 2L) {
+    stop(
+      "Usage: Rscript inst/scripts/sanitize_codexbar.R <raw_usage.json> <raw_cost.json>"
+    )
+  }
+
+  raw_usage_path <- args[[1L]]
+  raw_cost_path  <- args[[2L]]
+
+  # Determine output directory (inst/extdata/ relative to the package root)
+  # here::here() works when run from the package root; fall back to cwd-relative.
+  extdata_dir <- tryCatch(
+    {
+      requireNamespace("here", quietly = TRUE)
+      here::here("inst", "extdata")
+    },
+    error = function(e) file.path("inst", "extdata")
+  )
+  dir.create(extdata_dir, recursive = TRUE, showWarnings = FALSE)
+
+  out_usage_path <- file.path(extdata_dir, "codexbar_usage.json")
+  out_cost_path  <- file.path(extdata_dir, "codexbar_cost_daily.json")
+
+  # --- Process usage ---
+  cat("Reading", raw_usage_path, "...\n")
+  if (!file.exists(raw_usage_path)) {
+    stop("Raw usage file not found: ", raw_usage_path)
+  }
+  usage_raw <- tryCatch(
+    jsonlite::read_json(raw_usage_path, simplifyVector = FALSE),
+    error = function(e) stop("Failed to parse usage JSON: ", conditionMessage(e))
+  )
+
+  usage_result <- sanitize_usage(usage_raw)
+  usage_json   <- jsonlite::toJSON(usage_result$sanitized, auto_unbox = TRUE, pretty = TRUE)
+
+  # Verify before writing
+  verify_no_pii_leak(usage_json, "codexbar_usage.json")
+
+  writeLines(usage_json, out_usage_path)
+  cat(sprintf("  Stripped %d PII field(s) -> %s\n",
+              usage_result$n_stripped, out_usage_path))
+
+  # --- Process cost ---
+  cat("Reading", raw_cost_path, "...\n")
+  if (!file.exists(raw_cost_path)) {
+    stop("Raw cost file not found: ", raw_cost_path)
+  }
+  cost_raw  <- tryCatch(
+    jsonlite::read_json(raw_cost_path, simplifyVector = FALSE),
+    error = function(e) stop("Failed to parse cost JSON: ", conditionMessage(e))
+  )
+  cost_json <- jsonlite::toJSON(cost_raw, auto_unbox = TRUE, pretty = TRUE)
+
+  # Cost payload has no PII — just verify path leaks
+  verify_no_pii_leak(cost_json, "codexbar_cost_daily.json")
+
+  writeLines(cost_json, out_cost_path)
+  cat(sprintf("  No PII fields expected -> %s\n", out_cost_path))
+
+  # --- Final verification ---
+  cat("\nVerification:\n")
+  for (info in list(
+    list(path = out_usage_path, label = "codexbar_usage.json"),
+    list(path = out_cost_path,  label = "codexbar_cost_daily.json")
+  )) {
+    txt <- paste(readLines(info$path, warn = FALSE), collapse = "\n")
+    n_remaining <- sum(vapply(SENSITIVE_VERIFY_PATTERNS, function(p) {
+      m <- gregexpr(p, txt, perl = TRUE)[[1L]]
+      sum(m > 0L)
+    }, integer(1L)))
+    pii_remaining <- sum(vapply(PII_USAGE_FIELDS, function(f) {
+      grepl(paste0('"', f, '"'), txt, fixed = TRUE)
+    }, logical(1L)))
+
+    cat(sprintf("  %s: %d path leak(s), %d PII field(s) remaining\n",
+                info$label, n_remaining, pii_remaining))
+    if (n_remaining > 0L || pii_remaining > 0L) {
+      stop("Sanitization incomplete — leaks remain in ", info$label)
+    }
+  }
+
+  cat("\nDone. Both CodexBar output files are clean.\n")
+}

--- a/tests/testthat/fixtures/codexbar_cost_fixture.json
+++ b/tests/testthat/fixtures/codexbar_cost_fixture.json
@@ -1,0 +1,97 @@
+[
+  {
+    "provider": "claude",
+    "source": "local",
+    "updatedAt": "2026-05-25T09:00:00Z",
+    "historyDays": 30,
+    "daily": [
+      {
+        "date": "2026-05-24",
+        "totalCost": 1.23,
+        "totalTokens": 45000,
+        "inputTokens": 30000,
+        "outputTokens": 10000,
+        "cacheReadTokens": 4000,
+        "cacheCreationTokens": 1000,
+        "modelsUsed": ["claude-sonnet-4-6"],
+        "modelBreakdowns": [
+          {
+            "modelName": "claude-sonnet-4-6",
+            "cost": 1.23,
+            "totalTokens": 45000,
+            "inputTokens": 30000,
+            "outputTokens": 10000,
+            "cacheReadTokens": 4000,
+            "cacheCreationTokens": 1000
+          }
+        ]
+      },
+      {
+        "date": "2026-05-23",
+        "totalCost": 0.45,
+        "totalTokens": 12000,
+        "inputTokens": 8000,
+        "outputTokens": 3500,
+        "cacheReadTokens": 500,
+        "cacheCreationTokens": 0,
+        "modelsUsed": ["claude-haiku-4-5"],
+        "modelBreakdowns": [
+          {
+            "modelName": "claude-haiku-4-5",
+            "cost": 0.45,
+            "totalTokens": 12000,
+            "inputTokens": 8000,
+            "outputTokens": 3500,
+            "cacheReadTokens": 500,
+            "cacheCreationTokens": 0
+          }
+        ]
+      }
+    ],
+    "sessionTokens": 5000,
+    "sessionCostUSD": 0.10,
+    "last30DaysTokens": 57000,
+    "last30DaysCostUSD": 1.68,
+    "totals": {
+      "totalCost": 1.68,
+      "totalTokens": 57000
+    }
+  },
+  {
+    "provider": "openai",
+    "source": "local",
+    "updatedAt": "2026-05-25T09:00:00Z",
+    "historyDays": 30,
+    "daily": [
+      {
+        "date": "2026-05-24",
+        "totalCost": 0.08,
+        "totalTokens": 3000,
+        "inputTokens": 2000,
+        "outputTokens": 1000,
+        "cacheReadTokens": 0,
+        "cacheCreationTokens": 0,
+        "modelsUsed": ["gpt-4o-mini"],
+        "modelBreakdowns": [
+          {
+            "modelName": "gpt-4o-mini",
+            "cost": 0.08,
+            "totalTokens": 3000,
+            "inputTokens": 2000,
+            "outputTokens": 1000,
+            "cacheReadTokens": 0,
+            "cacheCreationTokens": 0
+          }
+        ]
+      }
+    ],
+    "sessionTokens": 0,
+    "sessionCostUSD": 0.0,
+    "last30DaysTokens": 3000,
+    "last30DaysCostUSD": 0.08,
+    "totals": {
+      "totalCost": 0.08,
+      "totalTokens": 3000
+    }
+  }
+]

--- a/tests/testthat/fixtures/codexbar_usage_fixture.json
+++ b/tests/testthat/fixtures/codexbar_usage_fixture.json
@@ -1,0 +1,43 @@
+[
+  {
+    "provider": "claude",
+    "version": "0.29.0",
+    "source": "api",
+    "status": "active",
+    "usage": {
+      "primary": {
+        "usedPercent": 42.5,
+        "windowMinutes": 60,
+        "resetsAt": "2026-05-25T10:00:00Z"
+      },
+      "secondary": {
+        "usedPercent": 10.0,
+        "windowMinutes": 300,
+        "resetsAt": "2026-05-25T15:00:00Z"
+      },
+      "updatedAt": "2026-05-25T09:00:00Z"
+    },
+    "credits": {
+      "remaining": 85.50,
+      "updatedAt": "2026-05-25T09:00:00Z"
+    }
+  },
+  {
+    "provider": "openai",
+    "version": "0.29.0",
+    "source": "api",
+    "status": "active",
+    "usage": {
+      "primary": {
+        "usedPercent": 5.0,
+        "windowMinutes": 60,
+        "resetsAt": "2026-05-25T10:00:00Z"
+      },
+      "updatedAt": "2026-05-25T09:00:00Z"
+    },
+    "credits": {
+      "remaining": 200.00,
+      "updatedAt": "2026-05-25T09:00:00Z"
+    }
+  }
+]

--- a/tests/testthat/fixtures/codexbar_usage_raw_fixture.json
+++ b/tests/testthat/fixtures/codexbar_usage_raw_fixture.json
@@ -1,0 +1,24 @@
+[
+  {
+    "provider": "claude",
+    "version": "0.29.0",
+    "source": "api",
+    "status": "active",
+    "usage": {
+      "primary": {
+        "usedPercent": 42.5,
+        "windowMinutes": 60,
+        "resetsAt": "2026-05-25T10:00:00Z"
+      },
+      "updatedAt": "2026-05-25T09:00:00Z",
+      "identity": "usr_synthetic_test_id_not_real",
+      "accountEmail": "test.user@example-fixture.invalid",
+      "accountOrganization": "ExampleOrg-Fixture",
+      "loginMethod": "oauth"
+    },
+    "credits": {
+      "remaining": 85.50,
+      "updatedAt": "2026-05-25T09:00:00Z"
+    }
+  }
+]

--- a/tests/testthat/test-codexbar.R
+++ b/tests/testthat/test-codexbar.R
@@ -1,0 +1,243 @@
+# test-codexbar.R — Unit tests + PII regression gate for CodexBar data layer.
+#
+# Tests cover:
+#   1. parse_codexbar_usage()  — shape + fixture row values
+#   2. parse_codexbar_cost()   — shape + fixture row values
+#   3. sanitize_codexbar.R helpers — PII stripping logic (strip_pii_from_usage_provider,
+#      sanitize_usage, verify_no_pii_leak)
+#   4. PII-leak regression gate — no accountEmail/@/accountOrganization/loginMethod
+#      in sanitised fixture output
+
+# ---------------------------------------------------------------------------
+# Source the sanitizer helpers once at file level (same pattern as
+# test-sanitize-ccusage-all.R).  Setting the option first prevents the main()
+# block from running.
+# ---------------------------------------------------------------------------
+options(sanitize_codexbar_sourced_for_test = TRUE)
+source(system.file("scripts", "sanitize_codexbar.R", package = "llmtelemetry"))
+
+fixture_path <- function(fname) {
+  testthat::test_path("fixtures", fname)
+}
+
+# ---------------------------------------------------------------------------
+# 1. parse_codexbar_usage — shape
+# ---------------------------------------------------------------------------
+
+test_that("parse_codexbar_usage returns a tibble with correct columns from fixture", {
+  result <- parse_codexbar_usage(fixture_path("codexbar_usage_fixture.json"))
+
+  expect_s3_class(result, "tbl_df")
+  expected_cols <- c(
+    "provider", "limit_window", "used_pct", "window_minutes",
+    "resets_at", "credits_remaining", "source", "updated_at"
+  )
+  expect_named(result, expected_cols, ignore.order = TRUE)
+  expect_gt(nrow(result), 0L)
+})
+
+test_that("parse_codexbar_usage returns empty tibble for non-existent file", {
+  result <- parse_codexbar_usage("/nonexistent/path/codexbar_usage.json")
+
+  expect_s3_class(result, "tbl_df")
+  expect_equal(nrow(result), 0L)
+  expect_true("provider" %in% names(result))
+})
+
+test_that("parse_codexbar_usage extracts known fixture row correctly", {
+  result <- parse_codexbar_usage(fixture_path("codexbar_usage_fixture.json"))
+
+  claude_primary <- result[result$provider == "claude" &
+                             result$limit_window == "primary", ]
+  expect_equal(nrow(claude_primary), 1L)
+  expect_equal(claude_primary$used_pct,          42.5, tolerance = 1e-6)
+  expect_equal(claude_primary$window_minutes,      60L)
+  expect_equal(claude_primary$credits_remaining,   85.5, tolerance = 1e-6)
+  expect_equal(claude_primary$source,             "api")
+})
+
+test_that("parse_codexbar_usage handles multiple providers and windows", {
+  result <- parse_codexbar_usage(fixture_path("codexbar_usage_fixture.json"))
+
+  # Fixture: claude has 2 windows, openai has 1
+  expect_equal(nrow(result), 3L)
+  expect_setequal(unique(result$provider), c("claude", "openai"))
+  expect_setequal(
+    result$limit_window[result$provider == "claude"],
+    c("primary", "secondary")
+  )
+})
+
+# ---------------------------------------------------------------------------
+# 2. parse_codexbar_cost — shape
+# ---------------------------------------------------------------------------
+
+test_that("parse_codexbar_cost returns a tibble with correct columns from fixture", {
+  result <- parse_codexbar_cost(fixture_path("codexbar_cost_fixture.json"))
+
+  expect_s3_class(result, "tbl_df")
+  expected_cols <- c(
+    "provider", "date", "model", "cost", "total_tokens",
+    "input_tokens", "output_tokens",
+    "cache_read_tokens", "cache_creation_tokens"
+  )
+  expect_named(result, expected_cols, ignore.order = TRUE)
+  expect_gt(nrow(result), 0L)
+})
+
+test_that("parse_codexbar_cost returns empty tibble for non-existent file", {
+  result <- parse_codexbar_cost("/nonexistent/path/codexbar_cost_daily.json")
+
+  expect_s3_class(result, "tbl_df")
+  expect_equal(nrow(result), 0L)
+  expect_true("provider" %in% names(result))
+})
+
+test_that("parse_codexbar_cost extracts known fixture row correctly", {
+  result <- parse_codexbar_cost(fixture_path("codexbar_cost_fixture.json"))
+
+  row <- result[
+    result$provider == "claude" &
+      result$date == "2026-05-24" &
+      result$model == "claude-sonnet-4-6",
+  ]
+  expect_equal(nrow(row), 1L)
+  expect_equal(row$cost,                  1.23,  tolerance = 1e-6)
+  expect_equal(row$total_tokens,          45000, tolerance = 1e-6)
+  expect_equal(row$input_tokens,          30000, tolerance = 1e-6)
+  expect_equal(row$output_tokens,         10000, tolerance = 1e-6)
+  expect_equal(row$cache_read_tokens,     4000,  tolerance = 1e-6)
+  expect_equal(row$cache_creation_tokens, 1000,  tolerance = 1e-6)
+})
+
+test_that("parse_codexbar_cost expands model breakdowns (one row per provider x date x model)", {
+  result <- parse_codexbar_cost(fixture_path("codexbar_cost_fixture.json"))
+
+  # Fixture: claude has 2 dates (1 model each) + openai has 1 date (1 model) = 3 rows
+  expect_equal(nrow(result), 3L)
+  expect_setequal(unique(result$provider), c("claude", "openai"))
+  expect_true("gpt-4o-mini" %in% result$model)
+})
+
+test_that("parse_codexbar_cost numeric columns are non-negative", {
+  result <- parse_codexbar_cost(fixture_path("codexbar_cost_fixture.json"))
+
+  numeric_cols <- c(
+    "cost", "total_tokens", "input_tokens", "output_tokens",
+    "cache_read_tokens", "cache_creation_tokens"
+  )
+  for (col in numeric_cols) {
+    expect_true(all(result[[col]] >= 0, na.rm = TRUE),
+                info = sprintf("Column '%s' must be non-negative", col))
+  }
+})
+
+# ---------------------------------------------------------------------------
+# 3. sanitize_codexbar.R helpers — PII stripping
+# (functions sourced at file level above)
+# ---------------------------------------------------------------------------
+
+test_that("strip_pii_from_usage_provider removes all four PII fields from usage sub-object", {
+  raw <- list(
+    provider = "claude",
+    usage = list(
+      primary        = list(usedPercent = 50, windowMinutes = 60, resetsAt = "2026-01-01T00:00:00Z"),
+      updatedAt      = "2026-01-01T00:00:00Z",
+      accountEmail   = "secret@example.com",
+      accountOrganization = "SecretOrg",
+      identity       = "uid_secret",
+      loginMethod    = "sso"
+    ),
+    credits = list(remaining = 100)
+  )
+
+  cleaned <- strip_pii_from_usage_provider(raw)
+
+  expect_null(cleaned[["usage"]][["accountEmail"]])
+  expect_null(cleaned[["usage"]][["accountOrganization"]])
+  expect_null(cleaned[["usage"]][["identity"]])
+  expect_null(cleaned[["usage"]][["loginMethod"]])
+
+  # Non-PII fields must survive
+  expect_equal(cleaned[["provider"]], "claude")
+  expect_equal(cleaned[["usage"]][["primary"]][["usedPercent"]], 50)
+  expect_equal(cleaned[["credits"]][["remaining"]], 100)
+})
+
+test_that("sanitize_usage removes PII from all providers and counts stripped fields", {
+  raw <- list(
+    list(
+      provider = "claude",
+      usage = list(accountEmail = "a@b.com", accountOrganization = "Org",
+                   identity = "id1", loginMethod = "oauth",
+                   updatedAt = "2026-01-01T00:00:00Z",
+                   primary = list(usedPercent = 10, windowMinutes = 60,
+                                  resetsAt = "2026-01-01T01:00:00Z"))
+    ),
+    list(
+      provider = "openai",
+      usage = list(accountEmail = "x@y.com", accountOrganization = "OrgX",
+                   identity = "id2", loginMethod = "key",
+                   updatedAt = "2026-01-01T00:00:00Z")
+    )
+  )
+
+  result <- sanitize_usage(raw)
+
+  expect_equal(result$n_stripped, 8L)  # 4 PII fields * 2 providers
+  expect_null(result$sanitized[[1L]][["usage"]][["accountEmail"]])
+  expect_null(result$sanitized[[2L]][["usage"]][["accountOrganization"]])
+  expect_equal(result$sanitized[[1L]][["provider"]], "claude")
+})
+
+# ---------------------------------------------------------------------------
+# 4. PII-leak regression gate — sanitised fixture output is clean
+# ---------------------------------------------------------------------------
+
+test_that("sanitised codexbar_usage_fixture contains no PII fields or @ signs", {
+  raw_list <- jsonlite::read_json(
+    fixture_path("codexbar_usage_raw_fixture.json"),
+    simplifyVector = FALSE
+  )
+
+  result <- sanitize_usage(raw_list)
+  clean_json <- jsonlite::toJSON(result$sanitized, auto_unbox = TRUE, pretty = TRUE)
+
+  # No PII field names
+  expect_false(grepl('"accountEmail"',        clean_json, fixed = TRUE),
+               label = "sanitised usage must not contain accountEmail field")
+  expect_false(grepl('"accountOrganization"', clean_json, fixed = TRUE),
+               label = "sanitised usage must not contain accountOrganization field")
+  expect_false(grepl('"identity"',            clean_json, fixed = TRUE),
+               label = "sanitised usage must not contain identity field")
+  expect_false(grepl('"loginMethod"',         clean_json, fixed = TRUE),
+               label = "sanitised usage must not contain loginMethod field")
+
+  # No @ signs (email addresses; URL schemas like @ are absent in this fixture JSON)
+  expect_false(grepl("@",                     clean_json, fixed = TRUE),
+               label = "sanitised usage must not contain @ (email address)")
+})
+
+test_that("clean codexbar_usage_fixture passes verify_no_pii_leak without error", {
+  clean_text <- paste(
+    readLines(fixture_path("codexbar_usage_fixture.json"), warn = FALSE),
+    collapse = "\n"
+  )
+
+  expect_no_error(
+    verify_no_pii_leak(clean_text, "codexbar_usage_fixture.json"),
+    message = "Clean fixture must pass verify_no_pii_leak without error"
+  )
+})
+
+test_that("cost fixture passes verify_no_pii_leak (cost has no PII)", {
+  cost_text <- paste(
+    readLines(fixture_path("codexbar_cost_fixture.json"), warn = FALSE),
+    collapse = "\n"
+  )
+
+  expect_no_error(
+    verify_no_pii_leak(cost_text, "codexbar_cost_fixture.json"),
+    message = "Cost fixture must pass verify_no_pii_leak without error"
+  )
+})


### PR DESCRIPTION
## Summary

- Adds `parse_codexbar_usage()` and `parse_codexbar_cost()` in `R/codexbar.R` — returns tibbles of usage windows and per-provider/date/model cost breakdowns from CodexBar CLI JSON output.
- Adds `inst/scripts/sanitize_codexbar.R` — strips four PII fields (`accountEmail`, `accountOrganization`, `identity`, `loginMethod`) and path-leaking error messages before writing to `inst/extdata/`.
- Adds `exec/refresh_codexbar.sh` — captures `codexbar usage` + `codexbar cost` CLI output, tolerates non-zero exit from single-provider 401s, calls sanitiser; no git commit/push step.
- Adds 54 tests (FAIL 0 | WARN 0 | SKIP 0 | PASS 54) including PII regression gate.
- Gitignores `inst/extdata/codexbar_*.json` so real captured data is never committed.
- This is a **complementary** source — does not replace or modify the existing `ccusage` pipeline.

## Test plan

- [ ] `devtools::test(filter = "codexbar")` — all 54 tests pass
- [ ] `bash exec/refresh_codexbar.sh` — runs without error when `codexbar` is installed
- [ ] `grep -c 'accountEmail\|@\|/Users/' inst/extdata/codexbar_usage.json` returns 0
- [ ] No `inst/extdata/codexbar_*.json` committed (gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)