### PR TITLE
fix(codexbar): deterministic output dir + nix-shell + launchd PATH

### DIFF
--- a/exec/refresh_codexbar.sh
+++ b/exec/refresh_codexbar.sh
@@ -28,7 +28,7 @@ set -uo pipefail
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
-export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+export PATH="/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PKG_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
@@ -112,23 +112,29 @@ if [ ! -f "${SANITIZE_SCRIPT}" ]; then
   exit 1
 fi
 
-# Use Rscript directly; if not on PATH try the nix-shell for this project.
-if command -v Rscript > /dev/null 2>&1; then
-  if Rscript "${SANITIZE_SCRIPT}" "${TMP_USAGE}" "${TMP_COST}" >> "${LOG_FILE}" 2>&1; then
-    log "Sanitization complete"
+# Always prefer the project's nix-shell so R resolves to the correct binary
+# and here::here() cannot write to a different repo.  Pass the explicit
+# output dir as arg 3 so the script never falls back to a cwd-relative path.
+# Bare Rscript is a last resort; it also receives the explicit out-dir + cwd
+# so it still writes to the right place.
+if command -v nix-shell > /dev/null 2>&1 && [ -f "${PKG_ROOT}/default.nix" ]; then
+  if (cd "${PKG_ROOT}" && nix-shell "${PKG_ROOT}/default.nix" --run "Rscript inst/scripts/sanitize_codexbar.R '${TMP_USAGE}' '${TMP_COST}' '${PKG_ROOT}/inst/extdata'") >> "${LOG_FILE}" 2>&1; then
+    log "Sanitization complete (nix-shell)"
+  else
+    log "ERROR: sanitize_codexbar.R failed via nix-shell — check ${LOG_FILE}"
+    exit 1
+  fi
+elif command -v Rscript > /dev/null 2>&1; then
+  # Fallback: bare Rscript, still cwd=PKG_ROOT + explicit out-dir so it writes to the right place
+  if (cd "${PKG_ROOT}" && Rscript inst/scripts/sanitize_codexbar.R "${TMP_USAGE}" "${TMP_COST}" "${PKG_ROOT}/inst/extdata") >> "${LOG_FILE}" 2>&1; then
+    log "Sanitization complete (bare Rscript fallback)"
   else
     log "ERROR: sanitize_codexbar.R failed — check ${LOG_FILE}"
     exit 1
   fi
 else
-  log "Rscript not on PATH — trying nix-shell"
-  NIX_SHELL_CMD="Rscript ${SANITIZE_SCRIPT} ${TMP_USAGE} ${TMP_COST}"
-  if nix-shell "${PKG_ROOT}/default.nix" --run "${NIX_SHELL_CMD}" >> "${LOG_FILE}" 2>&1; then
-    log "Sanitization complete (via nix-shell)"
-  else
-    log "ERROR: sanitize_codexbar.R failed via nix-shell — check ${LOG_FILE}"
-    exit 1
-  fi
+  log "ERROR: neither nix-shell nor Rscript available"
+  exit 1
 fi
 
 log "Done — inst/extdata/codexbar_usage.json and codexbar_cost_daily.json updated"

--- a/inst/scripts/sanitize_codexbar.R
+++ b/inst/scripts/sanitize_codexbar.R
@@ -193,15 +193,18 @@ if (!interactive() &&
   raw_usage_path <- args[[1L]]
   raw_cost_path  <- args[[2L]]
 
-  # Determine output directory (inst/extdata/ relative to the package root)
-  # here::here() works when run from the package root; fall back to cwd-relative.
-  extdata_dir <- tryCatch(
-    {
-      requireNamespace("here", quietly = TRUE)
-      here::here("inst", "extdata")
-    },
-    error = function(e) file.path("inst", "extdata")
-  )
+  # Determine output directory.
+  # Arg 3 (explicit out-dir) takes priority — ensures the caller controls where
+  # output lands regardless of cwd.  here::here() is the second choice (works
+  # when run from the package root); cwd-relative is a last resort.
+  extdata_dir <- if (length(args) >= 3L && nzchar(args[[3L]])) {
+    args[[3L]]
+  } else {
+    tryCatch(
+      here::here("inst", "extdata"),
+      error = function(e) file.path("inst", "extdata")
+    )
+  }
   dir.create(extdata_dir, recursive = TRUE, showWarnings = FALSE)
 
   out_usage_path <- file.path(extdata_dir, "codexbar_usage.json")


### PR DESCRIPTION
## Summary

- End-to-end run wrote sanitized CodexBar JSON to the caller's repo because `here::here()` resolved to the wrong CWD (an llm worktree was the caller, not llmtelemetry). Fixed by adding an explicit optional 3rd arg to `sanitize_codexbar.R` and always passing `${PKG_ROOT}/inst/extdata` from the shell script.
- `refresh_codexbar.sh` lacked `/nix/var/nix/profiles/default/bin` on PATH, so under launchd neither `nix-shell` nor `Rscript` would resolve (same class as JohnGavin/llm#235). Fixed by prepending the nix profile dir.
- Shell script previously preferred bare Rscript over nix-shell. Now always tries nix-shell first (correct R binary + correct package closure); bare Rscript is a last-resort fallback that also passes cwd + explicit out-dir.

Refs JohnGavin/llm#184, JohnGavin/llm#235.

## Test plan

- [ ] `bash -n exec/refresh_codexbar.sh` exits 0 (syntax OK)
- [ ] Fixture-based sanitizer run writes to `/tmp/cbarfix_out/` (not `inst/extdata/`)
- [ ] `grep -ciE "accountEmail|accountOrganization|loginMethod|@" /tmp/cbarfix_out/codexbar_usage.json` = 0
- [ ] `git status --short` shows only the 2 edited script files

🤖 Generated with [Claude Code](https://claude.com/claude-code)