### PR TITLE
ci(codexbar): overlay data-branch JSON for daily report [INTERIM #229]

### DIFF
--- a/.github/workflows/daily-report.yaml
+++ b/.github/workflows/daily-report.yaml
@@ -33,6 +33,13 @@ jobs:
             any::purrr
             local::.
 
+      - name: Overlay CodexBar data from data branch  # INTERIM #229 — remove when resolved
+        continue-on-error: true
+        run: |
+          git fetch origin data || true
+          git checkout origin/data -- inst/extdata/codexbar_usage.json inst/extdata/codexbar_cost_daily.json 2>/dev/null \
+            || echo "No codexbar data on data branch yet — email will show 'not yet available'"
+
       - name: Build email HTML
         run: Rscript inst/scripts/send_daily_email.R --build-only
 


### PR DESCRIPTION
## Summary

Stopgap for #229 — codexbar data lives on the unprotected `data` branch; this overlays it into the CI working tree before the email build step.

- `continue-on-error: true` so a missing `data` branch never breaks the daily report
- Step is marked `# INTERIM #229 — remove when resolved` for easy discovery
- Inserts after `setup-r-dependencies` and before `Build email HTML`, so the existing local-file-reading R code picks up the JSON files without changes

## Test plan

- [ ] Trigger `workflow_dispatch` run and confirm the overlay step passes when `data` branch has the files
- [ ] Confirm the overlay step shows "No codexbar data on data branch yet" warning (not a failure) when files are absent
- [ ] Do NOT merge until #229 is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)