### PR TITLE
feat(email): optional recipient override (delivery diagnostics)

### DIFF
--- a/.github/workflows/self-review-email.yml
+++ b/.github/workflows/self-review-email.yml
@@ -20,6 +20,10 @@ on:
         description: "extra detail line"
         required: false
         default: ""
+      to:
+        description: "Override recipient (default: GMAIL_USERNAME)"
+        required: false
+        default: ""
 
 jobs:
   send:
@@ -31,6 +35,7 @@ jobs:
       SR_COUNT: ${{ github.event.inputs.count }}
       SR_RUN_DATE: ${{ github.event.inputs.run_date }}
       SR_DETAILS: ${{ github.event.inputs.details }}
+      SR_TO: ${{ github.event.inputs.to }}
     steps:
       - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2

--- a/inst/scripts/send_self_review_email.R
+++ b/inst/scripts/send_self_review_email.R
@@ -13,6 +13,9 @@ if (!nzchar(run_date)) run_date <- format(Sys.Date())
 gmail_user <- Sys.getenv("GMAIL_USERNAME")
 gmail_pass <- Sys.getenv("GMAIL_APP_PASSWORD")
 
+recipient <- Sys.getenv("SR_TO", "")
+if (!nzchar(recipient)) recipient <- gmail_user
+
 emoji   <- if (identical(result, "PASS")) "✅" else "⚠️"
 subject <- sprintf("%s Overnight self-review: %s (%s)", emoji, result, run_date)
 
@@ -46,7 +49,7 @@ if (nzchar(gmail_user) && nzchar(gmail_pass)) {
   )
   tryCatch({
     smtp_send(
-      email = email, to = gmail_user, from = gmail_user,
+      email = email, to = recipient, from = gmail_user,
       subject = subject, credentials = smtp_creds
     )
     message("Self-review email sent: ", subject)


### PR DESCRIPTION
Adds a 'to' workflow_dispatch input + SR_TO env so we can send a self-review email to an explicit address, to isolate why daily-report self-sends to GMAIL_USERNAME aren't arriving. Default empty = unchanged behaviour.