### PR TITLE
fix(email): deliver reports to REPORT_RECIPIENT (sender != reader inbox)

### DIFF
--- a/.github/workflows/daily-report.yaml
+++ b/.github/workflows/daily-report.yaml
@@ -12,6 +12,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       GMAIL_USERNAME: ${{ secrets.GMAIL_USERNAME }}
       GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+      REPORT_RECIPIENT: ${{ secrets.REPORT_RECIPIENT }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/self-review-email.yml
+++ b/.github/workflows/self-review-email.yml
@@ -31,6 +31,7 @@ jobs:
     env:
       GMAIL_USERNAME: ${{ secrets.GMAIL_USERNAME }}
       GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+      REPORT_RECIPIENT: ${{ secrets.REPORT_RECIPIENT }}
       SR_RESULT: ${{ github.event.inputs.result }}
       SR_COUNT: ${{ github.event.inputs.count }}
       SR_RUN_DATE: ${{ github.event.inputs.run_date }}

--- a/inst/scripts/send_daily_email.R
+++ b/inst/scripts/send_daily_email.R
@@ -72,10 +72,12 @@ if (send_only) {
     port        = 465,
     use_ssl     = TRUE
   )
+  report_to <- Sys.getenv("REPORT_RECIPIENT", "")
+  if (!nzchar(report_to)) report_to <- gmail_user
   tryCatch({
     smtp_send(
       email       = email,
-      to          = gmail_user,
+      to          = report_to,
       from        = gmail_user,
       subject     = sprintf("LLM Telemetry Report - %s", today),
       credentials = smtp_creds
@@ -1283,10 +1285,12 @@ smtp_creds <- creds_envvar(
   use_ssl = TRUE
 )
 
+report_to <- Sys.getenv("REPORT_RECIPIENT", "")
+if (!nzchar(report_to)) report_to <- gmail_user
 tryCatch({
   smtp_send(
     email = email,
-    to = gmail_user,
+    to = report_to,
     from = gmail_user,
     subject = sprintf("LLM Telemetry Report - %s", today),
     credentials = smtp_creds

--- a/inst/scripts/send_self_review_email.R
+++ b/inst/scripts/send_self_review_email.R
@@ -14,6 +14,7 @@ gmail_user <- Sys.getenv("GMAIL_USERNAME")
 gmail_pass <- Sys.getenv("GMAIL_APP_PASSWORD")
 
 recipient <- Sys.getenv("SR_TO", "")
+if (!nzchar(recipient)) recipient <- Sys.getenv("REPORT_RECIPIENT", "")
 if (!nzchar(recipient)) recipient <- gmail_user
 
 emoji   <- if (identical(result, "PASS")) "✅" else "⚠️"


### PR DESCRIPTION
## Summary

Confirmed via explicit-recipient test: GMAIL_USERNAME is the sender account, not the user's inbox. Reports now send to the REPORT_RECIPIENT secret (falls back to gmail_user). Fixes daily report + self-review email non-delivery.

- `send_daily_email.R`: resolve `report_to` from `REPORT_RECIPIENT` env var before both `smtp_send` calls (the `--send-only` path and the default build-then-send path); `from` stays `gmail_user`
- `send_self_review_email.R`: extend fallback chain to `SR_TO → REPORT_RECIPIENT → gmail_user`
- `daily-report.yaml` + `self-review-email.yml`: expose `REPORT_RECIPIENT: ${{ secrets.REPORT_RECIPIENT }}` in job env

## Test plan

- [ ] Confirm `REPORT_RECIPIENT` secret is set in repo Settings → Secrets to the user's real inbox address
- [ ] Trigger `daily-report.yaml` via `workflow_dispatch` and verify email arrives in the user's inbox (not the sender account)
- [ ] Trigger `self-review-email.yml` via `workflow_dispatch` with `SR_TO` unset and verify delivery to `REPORT_RECIPIENT`
- [ ] Verify fallback: if `REPORT_RECIPIENT` secret is absent/empty, email still sends to `gmail_user` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)